### PR TITLE
GtkListStore refactoring

### DIFF
--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -36,9 +36,8 @@ def dialog(model, selection, window):
 
     crop = [0.0, 0.0, 0.0, 0.0]
     if selection:
-        path = selection[0]
-        pos = model.get_iter(path)
-        crop = [model.get_value(pos, 7 + side) for side in range(4)]
+        pos = model.get_iter(selection[0])
+        crop = list(model.get_value(pos, 0).crop)
 
     dialog = Gtk.Dialog(
         title=(_('Crop Selected Pages')),
@@ -110,10 +109,10 @@ def white_borders(model, selection, pdfqueue):
     crop = []
     for path in selection:
         it = model.get_iter(path)
-        nfile, npage = model.get(it, 2, 3,)
-        pdfdoc = pdfqueue[nfile - 1]
+        p = model.get_value(it, 0)
+        pdfdoc = pdfqueue[p.nfile - 1]
 
-        page = pdfdoc.document.get_page(npage - 1)
+        page = pdfdoc.document.get_page(p.npage - 1)
         w, h = page.get_size()
         w = int(w)
         h = int(h)

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -24,10 +24,9 @@ from . import metadata
 from decimal import Decimal
 
 
-def _mediabox(row, angle, angle0, box):
+def _mediabox(crop, angle, angle0, box):
     """ Return the cropped media box for a given page """
-    crop = row[7:11]
-    if crop != [0., 0., 0., 0.]:
+    if crop != (0., 0., 0., 0.):
         rotate_times = int(round(((angle + angle0) % 360) / 90) % 4)
         crop_init = crop
         if rotate_times != 0:
@@ -69,8 +68,8 @@ def export(input_files, pages, file_out, mode, mdata):
     pdf_output = pikepdf.Pdf.new()
     pdf_input = [pikepdf.open(p.copyname) for p in input_files]
     for row in pages:
-        current_page = pdf_input[row[2] - 1].pages[row[3] - 1]
-        angle = row[6]
+        current_page = pdf_input[row.nfile - 1].pages[row.npage - 1]
+        angle = row.angle
         angle0 = current_page.Rotate if '/Rotate' in current_page else 0
         new_page = pdf_output.copy_foreign(current_page)
         # Workaround for pikepdf <= 1.10.1
@@ -87,7 +86,7 @@ def export(input_files, pages, file_out, mode, mdata):
                       file=sys.stderr)
         if angle != 0:
             new_page.Rotate = angle + angle0
-        cropped = _mediabox(row, angle, angle0, current_page.MediaBox)
+        cropped = _mediabox(row.crop, angle, angle0, current_page.MediaBox)
         if cropped:
             new_page.MediaBox = cropped
         pdf_output.pages.append(new_page)

--- a/pdfarranger/undo.py
+++ b/pdfarranger/undo.py
@@ -46,14 +46,14 @@ class Manager(object):
         :param label: label of the action
         """
         self.states = self.states[:self.current]
-        self.states.append(([list(row) for row in self.model], self.label,))
+        self.states.append(([row[0].duplicate() for row in self.model], self.label,))
         self.current += 1
         self.label = label
         self.__refresh()
 
     def undo(self, _action, _param, _unused):
         if self.current == len(self.states):
-            self.states.append(([list(row) for row in self.model], self.label,))
+            self.states.append(([row[0].duplicate() for row in self.model], self.label,))
         state, self.label = self.states[self.current - 1]
         self.__set_state(state)
         self.current -= 1
@@ -72,10 +72,10 @@ class Manager(object):
 
     def __set_state(self, state):
         self.model.clear()
-        for row in state:
+        for page in state:
             # Do not reset the zoom level
-            row[4] = self.app.zoom_scale
-            self.model.append(row)
+            page.zoom = self.app.zoom_scale
+            self.model.append([page, page.description()])
 
     def __refresh(self):
         if self.undoaction:


### PR DESCRIPTION
The current core data structure of pdfarranger is currently a GtkListStore. It's difficult to read because of the number
of page attributes. With this PR GtkListStore (PdfArranger.model) now only have 2 columns: one for the descriptions, and one with the Page object which contains all other attributes.

This should help adding and manage new attributes to pages.