### PR TITLE
Scroll to selection instead of cursor and scroll also after rotating pages

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1653,6 +1653,7 @@ class PdfArranger(Gtk.Application):
     def rotate_page(self, selection, angle):
         model = self.iconview.get_model()
         rotated = False
+        page_width_old = max(p.size[0] * (1. - p.crop[0] - p.crop[1]) for p, _ in self.model)
         for path in selection:
             treeiter = model.get_iter(path)
             p = model.get_value(treeiter, 0)
@@ -1660,6 +1661,8 @@ class PdfArranger(Gtk.Application):
                 rotated = True
                 model.set_value(treeiter, 0, p)
             self.update_geometry(treeiter)
+        if page_width_old != max(p.size[0] * (1. - p.crop[0] - p.crop[1]) for p, _ in self.model):
+            GObject.timeout_add(200, self.scroll_to_selection)
         return rotated
 
     def split_pages(self, _action, _parameter, _unknown):


### PR DESCRIPTION
I think scroll to selection is better than to cursor, because:
* Cursor can be in window but still be invisible
* If page is selected with rubberband selection cursor will not be placed there and key f will not do what user expects
* Scroll after page rotate don't work good if we scroll to cursor

I had also missed that it would do a scroll after adding pages to iconview. So that is fixed also.

Edit:
Fixed some math faults