### PR TITLE
Eliminate unreferenced resources when saving to a file

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -101,9 +101,11 @@ def export(input_files, pages, file_out, mode, mdata):
             if n > 0:
                 # Add page number to filename
                 outname = "".join(parts[:-1]) + str(n + 1) + '.' + parts[-1]
+            outpdf.remove_unreferenced_resources()
             outpdf.save(outname)
     else:
         _set_meta(mdata, pdf_input, pdf_output)
+        pdf_output.remove_unreferenced_resources()
         pdf_output.save(file_out)
 
 def num_pages(filepath):


### PR DESCRIPTION
pikepdf recommends to call _remove_unreferenced_resourced()_  before calling _save()_. Adding the call shrank some of the test pdfs slightly. The impact may become larger when pdfarranger progresses towards content manipulation. Since pikepdf recommends the feature in the documentation and there are no visible adversary effects, I do not any reason to not call the routine. 