### PR TITLE
Add option to select all pages from same file

### DIFF
--- a/data/menu.ui
+++ b/data/menu.ui
@@ -157,9 +157,14 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
           <attribute name="target" type="i">3</attribute>
         </item>
         <item>
+          <attribute name="label" translatable="yes">All From _Same File</attribute>
+          <attribute name="action">win.select-same-file</attribute>
+          <attribute name="target" type="i">4</attribute>
+        </item>
+        <item>
           <attribute name="label" translatable="yes">_Invert Selection</attribute>
           <attribute name="action">win.select</attribute>
-          <attribute name="target" type="i">4</attribute>
+          <attribute name="target" type="i">5</attribute>
         </item>
       </section>
     </submenu>
@@ -259,9 +264,14 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
             <attribute name="target" type="i">3</attribute>
           </item>
           <item>
+            <attribute name="label" translatable="yes">All From _Same File</attribute>
+            <attribute name="action">win.select-same-file</attribute>
+            <attribute name="target" type="i">4</attribute>
+          </item>
+          <item>
             <attribute name="label" translatable="yes">_Invert Selection</attribute>
             <attribute name="action">win.select</attribute>
-            <attribute name="target" type="i">4</attribute>
+            <attribute name="target" type="i">5</attribute>
           </item>
         </section>
       </submenu>

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -428,6 +428,7 @@ class PdfArranger(Gtk.Application):
             ('copy', self.on_action_copy),
             ('paste', self.on_action_paste, 'i'),
             ('select', self.on_action_select, 'i'),
+            ('select-same-file', self.on_action_select, 'i'),
             ('about', self.about_dialog),
         ])
 
@@ -1166,7 +1167,7 @@ class PdfArranger(Gtk.Application):
 
     def on_action_select(self, _action, option, _unknown):
         """Selects items according to selected option."""
-        selectoptions = {0: 'ALL', 1: 'DESELECT', 2: 'ODD', 3: 'EVEN', 4: 'INVERT'}
+        selectoptions = {0: 'ALL', 1: 'DESELECT', 2: 'ODD', 3: 'EVEN', 4: 'SAME_FILE', 5:'INVERT'}
         selectoption = selectoptions[option.get_int32()]
         model = self.iconview.get_model()
         if selectoption == 'ALL':
@@ -1184,6 +1185,12 @@ class PdfArranger(Gtk.Application):
                 if page_number % 2:
                     self.iconview.unselect_path(row.path)
                 else:
+                    self.iconview.select_path(row.path)
+        elif selectoption == 'SAME_FILE':
+            selection = self.iconview.get_selected_items()
+            filenames = set(model[row][0].filename for row in selection)
+            for page_number, row in enumerate(model):
+                if model[page_number][0].filename in filenames:
                     self.iconview.select_path(row.path)
         elif selectoption == 'INVERT':
             for row in model:
@@ -1533,7 +1540,7 @@ class PdfArranger(Gtk.Application):
         for a, e in [("reverse-order", self.reverse_order_available(selection)),
                      ("delete", ne), ("duplicate", ne), ("crop", ne), ("rotate", ne),
                      ("export-selection", ne), ("cut", ne), ("copy", ne),
-                     ("split", ne)]:
+                     ("split", ne), ("select-same-file", ne)]:
             self.window.lookup_action(a).set_enabled(e)
         self.__update_statusbar()
 


### PR DESCRIPTION
I can think of a few cases when this could be useful:
* You want to reorder pdf files and don't want to search for where the pdf starts and ends
* Before you save you would like to highlight all pages from a pdf to more easily see if they are in the right place
* You put a page in wrong place but you can't find where it is
* You realize that you have used wrong pdf file and would like to remove it