### PR TITLE
Set negative margins only for iconview viewport

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -721,7 +721,8 @@ class PdfArranger(Gtk.Application):
             if self.vp_css_margin != 6 - margin:
                 # remove margin on top and bottom
                 self.vp_css_margin = 6 - margin
-                css_data = 'viewport {margin-top:' + str(self.vp_css_margin) + 'px;\
+                css_data = 'window viewport {\
+                margin-top:' + str(self.vp_css_margin) + 'px;\
                 margin-bottom:' + str(self.vp_css_margin) + 'px;}'
                 style_provider = Gtk.CssProvider()
                 style_provider.load_from_data(bytes(css_data.encode()))


### PR DESCRIPTION
It was affecting also the look of import and export dialog. Now it
apply css styling only for viewport which is a descendent of window.
https://developer.gnome.org/gtk3/stable/chap-css-overview.html
Close #301