### PR TITLE
Allow editing the creation and modification date

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     entry_points={
         'console_scripts': ['pdfarranger=pdfarranger.pdfarranger:main']
     },
-    install_requires=['pikepdf>=1.7.0'],
+    install_requires=['pikepdf>=1.7.0','python-dateutil>=2.4.0'],
     extras_require={
         'image': ['img2pdf>=0.3.4'],
     },


### PR DESCRIPTION
Closes #283 

- The user input of a date is parsed into the required format.
- Invalid date inputs are erased to have a smooth export.
- Two error checks are necessary. 1) In the standard case, when the user presses enter or changes rows, the `edited` signal is emitted and the input is validated. 2) It is possible to bypass the `edited` signal by pressing OK *during* the editing process. To capture this case, the implemented solution does an additional validation when the metadata is dumped.