### PR TITLE
Add option to select all pages with the same page format

### DIFF
--- a/data/menu.ui
+++ b/data/menu.ui
@@ -156,16 +156,21 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
           <attribute name="action">win.select</attribute>
           <attribute name="target" type="i">3</attribute>
         </item>
-        <item>
-          <attribute name="label" translatable="yes">All From _Same File</attribute>
-          <attribute name="action">win.select-same-file</attribute>
-          <attribute name="target" type="i">4</attribute>
-        </item>
-        <item>
-          <attribute name="label" translatable="yes">_Invert Selection</attribute>
-          <attribute name="action">win.select</attribute>
-          <attribute name="target" type="i">5</attribute>
-        </item>
+          <item>
+            <attribute name="label" translatable="yes">All From _Same File</attribute>
+            <attribute name="action">win.select-same-file</attribute>
+            <attribute name="target" type="i">4</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Same Page _Format</attribute>
+            <attribute name="action">win.select-same-format</attribute>
+            <attribute name="target" type="i">5</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">_Invert Selection</attribute>
+            <attribute name="action">win.select</attribute>
+            <attribute name="target" type="i">6</attribute>
+          </item>
       </section>
     </submenu>
     <section>
@@ -269,9 +274,14 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
             <attribute name="target" type="i">4</attribute>
           </item>
           <item>
+            <attribute name="label" translatable="yes">Same Page _Format</attribute>
+            <attribute name="action">win.select-same-format</attribute>
+            <attribute name="target" type="i">5</attribute>
+          </item>
+          <item>
             <attribute name="label" translatable="yes">_Invert Selection</attribute>
             <attribute name="action">win.select</attribute>
-            <attribute name="target" type="i">5</attribute>
+            <attribute name="target" type="i">6</attribute>
           </item>
         </section>
       </submenu>


### PR DESCRIPTION
A selection based on the page format facilitates the use of the absolute page scaling feature.

The most useful case is probably that a single page is selected and then the selection is extended to all pages of the same size. The implementation allows for multi-selection. I see some use cases when absolute scaling is applied incrementally or in conjunction with '`invert selection`.