### PR TITLE
menu: Add 'new' button to open new document

### DIFF
--- a/data/menu.ui
+++ b/data/menu.ui
@@ -27,6 +27,12 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
     </section>
     <section>
       <item>
+        <attribute name="label" translatable="yes">_New Window</attribute>
+        <attribute name="action">win.new</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
         <attribute name="label" translatable="yes">_Save</attribute>
         <attribute name="action">win.save</attribute>
         <attribute name="verb-icon">document-save-symbolic</attribute>

--- a/pdfarranger/config.py
+++ b/pdfarranger/config.py
@@ -30,6 +30,7 @@ _DEFAULT_ACCELS=[
     ('export-selection(2)', '<Primary>e'),
     ('export-all', '<Primary><Shift>e'),
     ('quit', '<Primary>q'),
+    ('new', '<Primary>n'),
     ('import', '<Primary>o'),
     ('zoom(5)', 'plus KP_Add <Primary>plus <Primary>KP_Add'),
     ('zoom(-5)', 'minus KP_Subtract <Primary>minus <Primary>KP_Subtract'),

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -28,6 +28,7 @@ import locale  # for multilanguage support
 import gettext
 import gc
 import copy
+import subprocess
 from urllib.request import url2pathname
 
 try:
@@ -383,6 +384,7 @@ class PdfArranger(Gtk.Application):
             ('reverse-order', self.reverse_order),
             ('save', self.on_action_save),
             ('save-as', self.on_action_save_as),
+            ('new', self.on_action_new),
             ('import', self.on_action_add_doc_activate),
             ('zoom', self.zoom_change, 'i'),
             ('quit', self.on_quit),
@@ -768,6 +770,19 @@ class PdfArranger(Gtk.Application):
             f = os.path.splitext(os.path.basename(f.filename))[0]
             all_files.add(f)
         return all_files
+
+    def exec_new_self(self):
+        subprocess.Popen([sys.executable, '-mpdfarranger'])
+
+    def on_action_new(self, _action, _param, _unknown):
+        display = Gdk.Display.get_default()
+        launch_context = display.get_app_launch_context()
+        desktop_file = "%s.desktop"%(self.get_application_id())
+        try:
+            app_info = Gio.DesktopAppInfo.new(desktop_file)
+            app_info.launch([], launch_context)
+        except TypeError as e:
+            self.exec_new_self()
 
     def on_action_save(self, _action, _param, _unknown):
         self.save_or_choose()


### PR DESCRIPTION
I was arranging PDFs, and was going to organize multiple files into
multiple PDFs. What I was missing was a way to create a new empty
document from withit PDF Arranger; this commits adds that.

It simply works by spawing a new instance of PDF Arranger using the app
launch context from Gdk, using the .desktop file of PDF Arranger itself,
which is what I was in fact was doing to create new documents, but via
the launch mechanism in the desktop environment.