### PR TITLE
Warn when TOC/forms are lost on export

### DIFF
--- a/pdfarranger/config.py
+++ b/pdfarranger/config.py
@@ -88,6 +88,8 @@ class Config(object):
         self.data = configparser.ConfigParser()
         self.data.add_section('window')
         self.data.read(Config._config_file(domain))
+        if 'preferences' not in self.data:
+            self.data.add_section('preferences')
         if 'accelerators' not in self.data:
             self.data.add_section('accelerators')
         a = self.data['accelerators']
@@ -118,6 +120,12 @@ class Config(object):
 
     def set_zoom_level(self, level):
         self.data.set('window', 'zoom-level', str(level))
+
+    def content_loss_warning(self):
+        return self.data.getboolean('preferences', 'content-loss-warning', fallback=True)
+
+    def set_content_loss_warning(self, enabled):
+        self.data.set('preferences', 'content-loss-warning', str(enabled))
 
     def save(self):
         conffile = Config._config_file(self.domain)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -810,6 +810,11 @@ class PdfArranger(Gtk.Application):
             to_export = [row[0] for row in self.model]
 
         m = metadata.merge(self.metadata, self.pdfqueue)
+        if self.config.content_loss_warning():
+            res, enabled = exporter.check_content(self.window, self.pdfqueue)
+            self.config.set_content_loss_warning(enabled)
+            if res == Gtk.ResponseType.CANCEL:
+                return # Abort
         exporter.export(self.pdfqueue, to_export, file_out, mode, m)
 
         if exportmode == 'ALL_TO_SINGLE':


### PR DESCRIPTION
Proposal to close #265

Fillable forms and outlines are lost on export. This commits screen for forms and outlines and displays a warning if any imported document contains such. The warning can be disabled and the choice is stored in the config file. I consider this a compromise that is not too annoying.

There are two things I am not happy with and ask you for your opinion.
- In the config file, the newly added `disable-warnings` feels misplaced in the category `[window]`. Opening a separate category for a single item does not appear reasonable either. Are more customizations expected so that a category `[preferences]` is justifiable?
- The warning appears if any of the documents has forms or outlines, even if the pages selected for export are not affected. The reason is that I cannot find an easy way to get the page on which a form is located.