### PR TITLE
Zoom to full page faster

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1613,15 +1613,25 @@ class PdfArranger(Gtk.Application):
         """ Action handle for zoom change """
         self.zoom_set(self.zoom_level + step.get_int32())
 
+    def get_full_sw_height(self):
+        """Get scrolledwindow height as it will be when progressbar is hidden."""
+        box = self.sw.get_parent()
+        sw_height = box.get_allocated_height()
+        sw_height -= self.status_bar.get_allocated_height()
+        sw_height -= self.status_bar.get_margin_top()
+        sw_height -= self.status_bar.get_margin_bottom()
+        sw_height -= box.get_children()[2].get_allocated_height()  # separator
+        return sw_height
+
     def zoom_to_full_page(self):
         """Zoom selected thumbnail to full page."""
         selection = self.iconview.get_selected_items()
-        if len(selection) != 1 or self.progress_bar.get_visible():
+        if len(selection) != 1:
             return
         self.zoom_full_page = True
         selected_page_nr = Gtk.TreePath.get_indices(selection[0])[0]
         sw_width = self.sw.get_allocated_width()
-        sw_height = self.sw.get_allocated_height()
+        sw_height = self.get_full_sw_height()
         page_width = max(p.width_in_points() for p, _ in self.model)
         page_height = max(p.height_in_points() for p, _ in self.model)
         max_page_height, i = max((p.height_in_pixel(), i) for i, (p, _) in enumerate(self.model))
@@ -1661,7 +1671,7 @@ class PdfArranger(Gtk.Application):
         last_cell_y = self.iconview.get_cell_rect(selection[-1])[1].y
         last_cell_height = self.iconview.get_cell_rect(selection[-1])[1].height
         selection_center = (last_cell_y + last_cell_height - first_cell_y) / 2 + 0.5
-        sw_height = self.sw.get_allocated_height()
+        sw_height = self.get_full_sw_height()
         sw_vadj.set_value(first_cell_y + selection_center + self.vp_css_margin - sw_height / 2)
         self.id_scroll_to_sel = None
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -580,12 +580,12 @@ class PdfArranger(Gtk.Application):
     def set_cellrenderer_data(_column, cell, model, it, _data=None):
         cell.set_page(model.get_value(it, 0))
 
-    def render(self):
+    def render(self, start_p=0):
         self.zoom_change_render = None
         if self.rendering_thread:
             self.rendering_thread.quit = True
             self.rendering_thread.join()
-        self.rendering_thread = PDFRenderer(self.model, self.pdfqueue, 1 / self.zoom_scale)
+        self.rendering_thread = PDFRenderer(self.model, self.pdfqueue, 1 / self.zoom_scale, start_p)
         self.rendering_thread.connect('update_thumbnail', self.update_thumbnail)
         self.rendering_thread.start()
         return False
@@ -616,7 +616,10 @@ class PdfArranger(Gtk.Application):
         return False
 
     def update_progress_bar(self, num):
-        fraction = float(num + 1) / len(self.model)
+        if num == -1:  # rendering (re)started
+            fraction = 0
+        else:
+            fraction = self.progress_bar.get_fraction() + 1 / len(self.model)
         self.progress_bar.set_fraction(fraction)
         if fraction >= 0.999:
             self.progress_bar.hide()
@@ -626,11 +629,12 @@ class PdfArranger(Gtk.Application):
             self.progress_bar.show()
 
     def update_thumbnail(self, _obj, num, thumbnail, resample):
-        page, _ = self.model[num]
-        page.resample = resample
-        page.zoom = self.zoom_scale
-        page.thumbnail = thumbnail
-        self.model[num][0] = page
+        if num != -1:
+            page, _ = self.model[num]
+            page.resample = resample
+            page.zoom = self.zoom_scale
+            page.thumbnail = thumbnail
+            self.model[num][0] = page
         self.update_progress_bar(num)
 
     def on_window_size_request(self, _window):
@@ -1626,7 +1630,7 @@ class PdfArranger(Gtk.Application):
         self.zoom_scale = min(zoom_scaleY_new, zoom_scaleX_new)
         for page, _ in self.model:
             page.zoom = self.zoom_scale
-        GObject.idle_add(self.render)
+        GObject.idle_add(self.render, selected_page_nr)
 
         # Set zoom level to nearest possible so zoom in/out works right
         self.zoom_level = -10
@@ -1974,33 +1978,54 @@ class PageAdder:
 
 class PDFRenderer(threading.Thread, GObject.GObject):
 
-    def __init__(self, model, pdfqueue, resample):
+    def __init__(self, model, pdfqueue, resample, start_p):
         threading.Thread.__init__(self)
         GObject.GObject.__init__(self)
         self.model = model
         self.pdfqueue = pdfqueue
         self.resample = resample
         self.quit = False
+        self.start_p = start_p
 
     def run(self):
-        for idx, row in enumerate(self.model):
-            p = row[0]
-            if self.quit:
-                return
-            pdfdoc = self.pdfqueue[p.nfile - 1]
-            page = pdfdoc.document.get_page(p.npage - 1)
-            w, h = page.get_size()
-            scale = p.scale / self.resample
-            thumbnail = cairo.ImageSurface(cairo.FORMAT_ARGB32,
-                                           int(w * scale),
-                                           int(h * scale))
-            cr = cairo.Context(thumbnail)
-            if scale != 1.:
-                cr.scale(scale, scale)
-            page.render(cr)
-            GObject.idle_add(self.emit, 'update_thumbnail',
-                             idx, thumbnail, self.resample,
-                             priority=GObject.PRIORITY_LOW)
+        idx = -1  # signal rendering (re)started for progressbar
+        GObject.idle_add(self.emit, 'update_thumbnail',
+                            idx, None, 0.0,
+                            priority=GObject.PRIORITY_LOW)
+        if self.start_p == 0:
+            for idx, row in enumerate(self.model):
+                self.update(idx, row)
+        else:
+            # Rendering order: begin from start_p, then expand around start_p
+            self.update(self.start_p, self.model[self.start_p])
+            for cnt in range(1, len(self.model)):
+                previous_p = self.start_p - cnt
+                next_p = self.start_p + cnt
+                if previous_p < 0 and next_p > len(self.model):
+                    return
+                if previous_p >= 0:
+                    self.update(previous_p, self.model[previous_p])
+                if next_p < len(self.model):
+                    self.update(next_p, self.model[next_p])
+
+    def update(self, idx, row):
+        p = row[0]
+        if self.quit:
+            return
+        pdfdoc = self.pdfqueue[p.nfile - 1]
+        page = pdfdoc.document.get_page(p.npage - 1)
+        w, h = page.get_size()
+        scale = p.scale / self.resample
+        thumbnail = cairo.ImageSurface(cairo.FORMAT_ARGB32,
+                                        int(w * scale),
+                                        int(h * scale))
+        cr = cairo.Context(thumbnail)
+        if scale != 1.:
+            cr.scale(scale, scale)
+        page.render(cr)
+        GObject.idle_add(self.emit, 'update_thumbnail',
+                            idx, thumbnail, self.resample,
+                            priority=GObject.PRIORITY_LOW)
 
 
 def main():

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -642,11 +642,15 @@ class PdfArranger(Gtk.Application):
         if len(self.model) > 0:
             item_width = max(row[0].width_in_pixel() for row in self.model)
             item_padding = self.iconview.get_item_padding()
-            cellthmb_xpad, _cellthmb_ypad = self.cellthmb.get_padding()
+            cellthmb_xpad, cellthmb_ypad = self.cellthmb.get_padding()
             border_and_shadow = 7  # 2*th1+th2 set in iconview.py
             # cell width min limit 50 is set in gtkiconview.c
             cell_width = max(item_width + 2 * cellthmb_xpad + border_and_shadow, 50)
-            self.cellthmb.set_fixed_size(cell_width, -1)
+            cell_height = -1
+            if self.zoom_full_page:
+                item_height = max(row[0].height_in_pixel() for row in self.model)
+                cell_height = item_height + 2 * cellthmb_ypad + border_and_shadow
+            self.cellthmb.set_fixed_size(cell_width, cell_height)
             padded_cell_width = cell_width + 2 * item_padding
             min_col_spacing = 5
             min_margin = 11
@@ -1608,11 +1612,10 @@ class PdfArranger(Gtk.Application):
         self.zoom_full_page = True
         self.scroll_to_selection_request = True
         selected_page_nr = Gtk.TreePath.get_indices(selection[0])[0]
-        page, _ = self.model[selected_page_nr]
         sw_width = self.sw.get_allocated_width()
         sw_height = self.sw.get_allocated_height()
         page_width = max(p.width_in_points() for p, _ in self.model)
-        page_height = page.height_in_points()
+        page_height = max(p.height_in_points() for p, _ in self.model)
         max_page_height, i = max((p.height_in_pixel(), i) for i, (p, _) in enumerate(self.model))
         path = Gtk.TreePath.new_from_indices([i])
         max_cell_height = self.iconview.get_cell_rect(path)[1].height


### PR DESCRIPTION
With the current implementation of "zoom to full page" the zoomed and rendered page will be visible after all pages have been completely rendered. With a pdf with many pages it can take a long time. These commits will make it zoom to full page much faster.

All of this is based on that we set a fixed cell height. ;-) But It is only enabled when we zoom to full page, so I think it is a good compromise.