### PR TITLE
Fix is_unsaved when passing files via command line

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -341,8 +341,6 @@ class PdfArranger(Gtk.Application):
         for f in files:
             a.addpages(f.get_path())
         a.commit(select_added=False, add_to_undomanager=True)
-        if len(files) == 1:
-            self.set_unsaved(False)
 
     def __build_from_file(self, path):
         """ Return the path of a resource file """


### PR DESCRIPTION
GUI imports set `is_unsaved` for any number of imported documents. With this fix, command line imports have the same behavior. A failed import (e.g. passing a directory `python3 -m pdfarranger .`) no longer set `is_unsaved`.