### PR TITLE
Fix page split on cropped page

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -223,7 +223,7 @@ class Page:
         left, right = self.crop[:2]
         newcrop = (1 + left - right) / 2
         newpage.crop[0] = newcrop
-        self.crop[1] = newcrop
+        self.crop[1] = 1 - newcrop
         return newpage
 
 


### PR DESCRIPTION
1) Set left crop to 50%, 2) split. The result has  a broken left page with a left crop of 50% and a right crop of 75% (should be: 25%). 

This commit fixes the right crop when the page split feature is applied to a page with crop.