### PR TITLE
Use less ram by not storing thumbnails in undomanager

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -103,10 +103,13 @@ class Page:
         ts = [self.filename, self.npage, self.angle, self.scale] + list(self.crop)
         return "\n".join([str(v) for v in ts])
 
-    def duplicate(self):
+    def duplicate(self, incl_thumbnail=True):
         r = copy.copy(self)
         r.crop = list(r.crop)
         r.size = list(r.size)
+        if incl_thumbnail == False:
+            del r.thumbnail  # to save ram
+            r.thumbnail = None
         return r
 
     def set_size(self, size):


### PR DESCRIPTION
Ram can be saved by not storing thumbnails in undomanager. In a side by side comparison with before and after this commit, (zooming in, doing changes and zooming out..) the latter usually use much less ram.
Ram is not always released when I expect it should, but zooming in/out and doing changes, ram can suddenly be released.

To my understanding "r.thumbnail = None" should be enough, but "del r.thumbnail" seems to make it more likely that ram is released.

This commit is still not (usually) successfull at the select all + delete case.

Related to #341