### PR TITLE
Merge split pages and grid split

### DIFF
--- a/data/menu.ui
+++ b/data/menu.ui
@@ -108,12 +108,6 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
         <item>
           <attribute name="label" translatable="yes">_Split Pages</attribute>
           <attribute name="action">win.split</attribute>
-          <attribute name="target" type="i">0</attribute>
-        </item>
-        <item>
-          <attribute name="label" translatable="yes">_Grid Split</attribute>
-          <attribute name="action">win.split</attribute>
-          <attribute name="target" type="i">1</attribute>
         </item>
         <item>
           <attribute name="label" translatable="yes">Cu_t</attribute>
@@ -332,12 +326,6 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
       <item>
         <attribute name="label" translatable="yes">_Split Pages</attribute>
         <attribute name="action">win.split</attribute>
-        <attribute name="target" type="i">0</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Grid Split</attribute>
-        <attribute name="action">win.split</attribute>
-        <attribute name="target" type="i">1</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Insert Blan_k Page</attribute>

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -298,7 +298,7 @@ class PdfArranger(Gtk.Application):
             ('quit', self.on_quit),
             ('undo', self.undomanager.undo),
             ('redo', self.undomanager.redo),
-            ('split', self.split_pages, 'i'),
+            ('split', self.split_pages),
             ('metadata', self.edit_metadata),
             ('cut', self.on_action_cut),
             ('copy', self.on_action_copy),
@@ -1656,19 +1656,12 @@ class PdfArranger(Gtk.Application):
             GObject.timeout_add(50, self.scroll_to_selection)
         return rotated
 
-    def split_pages(self, _action, option, _unknown):
+    def split_pages(self, _action, _parameter, _unknown):
         """ Split selected pages """
-        splitoptions = {0: 'HALF', 1: 'GRID'}
-        splitoption = splitoptions[option.get_int32()]
-        if splitoption == 'GRID':
-            diag = splitter.Dialog(self.window)
-            leftcrops, topcrops = diag.run_get()
-            if leftcrops is None or topcrops is None:
-                return
-        else:
-            leftcrops = [0.0, 0.5, 1.0]
-            topcrops = [0.0, 1.0]
-
+        diag = splitter.Dialog(self.window)
+        leftcrops, topcrops = diag.run_get()
+        if leftcrops is None or topcrops is None:
+            return
         model = self.iconview.get_model()
         self.set_unsaved(True)
         self.undomanager.commit("Split")

--- a/pdfarranger/splitter.py
+++ b/pdfarranger/splitter.py
@@ -23,7 +23,7 @@ class Dialog(Gtk.Dialog):
     """ A dialog box to split pages into a grid of pages"""
     def __init__(self, window):
         super().__init__(
-            title=_("Grid splitting"),
+            title=_("Split Pages"),
             parent=window,
             flags=Gtk.DialogFlags.MODAL,
             buttons=(
@@ -35,7 +35,7 @@ class Dialog(Gtk.Dialog):
         )
         self.set_default_response(Gtk.ResponseType.OK)
         self.set_resizable(False)
-        self.split_count = {'vertical' : 1, 'horizontal' : 1}
+        self.split_count = {'vertical' : 2, 'horizontal' : 1}
         self.even_splits = {'vertical' : True, 'horizontal' : True}
         self.vmodel = Gtk.ListStore(int, int)
         self.hmodel = Gtk.ListStore(int, int)
@@ -69,7 +69,7 @@ class Dialog(Gtk.Dialog):
         label.props.margin = 8
         label.props.margin_bottom = 6
         grid.attach(label, 0, 0, width=1, height=1)
-        adjustment = Gtk.Adjustment(value=1, lower=1, upper=20, step_incr=1)
+        adjustment = Gtk.Adjustment(value=self.split_count[direction], lower=1, upper=20, step_incr=1)
         self.spinbuttons[direction].set_adjustment(adjustment)
         self.spinbuttons[direction].connect("value-changed", self._update_split, direction)
         grid.attach(self.spinbuttons[direction], 1, 0, width=1, height=1)
@@ -85,7 +85,9 @@ class Dialog(Gtk.Dialog):
         label1 = {'vertical' : _("#Col"), 'horizontal' : _("#Row")}
         label2 = {'vertical' : _("Width in %"), 'horizontal' : _("Height in %")}
 
-        self.model[direction].append([1, 100])
+        split_count = self.split_count[direction]
+        for s in range(1, split_count + 1):
+            self.model[direction].append([s, 100 // split_count])
         treeview = Gtk.TreeView(model=self.model[direction])
         cr = Gtk.CellRendererText()
         heading = Gtk.TreeViewColumn(label1[direction], cr, text=0)


### PR DESCRIPTION
* Rename `grid split` to `split pages`
* A vertical split into two equal halves is the new default behavior.

This should cover everything discussed in #358.