### PR TITLE
Disable fuzzy matching in translations

### DIFF
--- a/po/cleanuppo.sh
+++ b/po/cleanuppo.sh
@@ -23,6 +23,6 @@
 cd "$(dirname $0)/.."
 for po in po/*.po
 do
-  # Remove #~ lines
-  msgattrib --no-obsolete -o "$po" "$po"
+  # Remove #~ lines and fuzzy
+  msgattrib --no-fuzzy --no-obsolete -o "$po" "$po"
 done

--- a/po/updatepo.sh
+++ b/po/updatepo.sh
@@ -24,5 +24,5 @@
 cd "$(dirname $0)/.."
 for po in po/*.po
 do
-  msgmerge --backup none -U "$po" po/pdfarranger.pot
+  msgmerge -N --backup none -U "$po" po/pdfarranger.pot
 done


### PR DESCRIPTION
Fuzzy matching sometimes leads to nonsense. I removed some of them in 719455ce5060b8d593619f99c0318b1d5aa8ed13 using google translate. On the other hand, fuzzy matching sometimes lead to a not so bad translation, yet I think it's not safe enough to be used by default. What's your opinion ?