### PR TITLE
Hide the file name of blank pages

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -248,6 +248,7 @@ class PDFDoc:
             if self.filename.startswith(tmp_dir) and basename is None:
                 # In the "Insert Blank Page" we don't need to copy self.filename
                 self.copyname = self.filename
+                self.basename = ""
             else:
                 fd, self.copyname = tempfile.mkstemp(suffix=".pdf", dir=tmp_dir)
                 os.close(fd)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -699,7 +699,9 @@ class PdfArranger(Gtk.Application):
 
     def active_file_names(self):
         """Returns the file names currently associated with pages in the model."""
-        return set(row[1].split('\n')[0] for row in self.model)
+        r = set(row[1].split('\n')[0] for row in self.model)
+        r.discard("")
+        return r
 
     def on_action_new(self, _action, _param, _unknown):
         """Start a new instance."""


### PR DESCRIPTION
Then blank page file name is always a temporary file which is meaningless to the user. We set it to None so it's not displayed.

This currently break copy/paste across instances. The problem is related to #291 so let's fix it before concidering this PR.