### PR TITLE
Fix slow paste-interleave-odd/even

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -378,8 +378,9 @@ class PageAdder:
                 path = self.app.model.get_path(it)
                 self.app.iconview.select_path(path)
             self.app.update_geometry(it)
-        GObject.idle_add(self.app.retitle)
-        GObject.idle_add(self.app.render)
+        if add_to_undomanager:
+            GObject.idle_add(self.app.retitle)
+            GObject.idle_add(self.app.render)
         self.pages = []
         return True
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1004,6 +1004,8 @@ class PdfArranger(Gtk.Application):
                     return
                 data = filepaths
             self.paste_pages_interleave(data, before, ref_to)
+            GObject.idle_add(self.retitle)
+            GObject.idle_add(self.render)
             self.iv_selection_changed_event()
 
     def read_from_clipboard(self):


### PR DESCRIPTION
If I paste-interleave-odd a 17MB pdf with 435 pages it takes over 100 seconds before rendering begins. 
After this commit rendering begins after 1 - 2 seconds.