### PR TITLE
Fix "crop white border" on rotated pages

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -99,15 +99,25 @@ class Page:
     def height_in_pixel(self):
         return int(0.5 + self.zoom * self.height_in_points())
 
-    def rotate(self, angle):
-        rotate_times = int(round(((-angle) % 360) / 90) % 4)
-        if rotate_times == 0:
-            return False
+    @staticmethod
+    def rotate_times(angle):
+        """Convert an angle in degree to a number of 90° rotation (integer)"""
+        return int(round(((-angle) % 360) / 90) % 4)
+
+    @staticmethod
+    def rotate_crop(croparray, rotate_times):
+        """Rotate a given crop array (left, right, top bottom) a number of time"""
         perm = [0, 2, 1, 3]
         for __ in range(rotate_times):
             perm.append(perm.pop(0))
         perm.insert(1, perm.pop(2))
-        self.crop = [self.crop[x] for x in perm]
+        return [croparray[x] for x in perm]
+
+    def rotate(self, angle):
+        rt = self.rotate_times(angle)
+        if rt == 0:
+            return False
+        self.crop = self.rotate_crop(self.crop, rt)
         self.angle = (self.angle + int(angle)) % 360
         return True
 

--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -323,7 +323,7 @@ def white_borders(model, selection, pdfqueue):
             if not allwhite:
                 break
 
-        crop.append(crop_this_page)
+        crop.append(p.rotate_crop(crop_this_page, p.rotate_times(p.angle)))
     return crop
 
 

--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -264,16 +264,21 @@ def white_borders(model, selection, pdfqueue):
         pdfdoc = pdfqueue[p.nfile - 1]
 
         page = pdfdoc.document.get_page(p.npage - 1)
+        # Always render pages at 72 dpi whatever the zoom or scale of the page
         w, h = page.get_size()
+        # FIXME: No longer ignore p.crop so we could do nested white border crop
         w = int(w)
         h = int(h)
         thumbnail = cairo.ImageSurface(cairo.FORMAT_ARGB32, w, h)
         cr = cairo.Context(thumbnail)
         page.render(cr)
+        # TODO: python list are dead slow compared to memoryview. It would
+        # be faster to create a memoryview full of 0 and then compare each row
+        # to it. memoryview have full native __eq__ operator which is fast.
         data = thumbnail.get_data().cast("i", shape=[h, w]).tolist()
 
         crop_this_page = [0.0, 0.0, 0.0, 0.0]
-
+        # TODO: Those 4 copy/past should be factorized
         # Left
         allwhite = True
         for col in range(w - 1):


### PR DESCRIPTION
* Related to #386
* Only fix the issue on rotated pages
* Cropped pages are still concidered are not cropped. This will be fixed later.