### PR TITLE
Fix displayed page range when using paste before

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -981,6 +981,8 @@ class PdfArranger(Gtk.Application):
                 self.paste_files(data, before, ref_to)
             else:
                 self.paste_pages(data, before, ref_to, select_added=False)
+            if pastemode == 'BEFORE':
+                self.__update_statusbar()
         elif pastemode in ['ODD', 'EVEN']:
             if data_is_filepaths:
                 # Generate data to send to paste_pages_interleave


### PR DESCRIPTION
The page numbers of the selection change when `paste before` is used. This fix adds the missing update of the status bar.