### PR TITLE
Normalize spelling: PDF Arranger

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![pdfarranger](https://github.com/pdfarranger/pdfarranger/workflows/pdfarranger/badge.svg)](https://github.com/pdfarranger/pdfarranger/actions?query=workflow%3Apdfarranger+branch%3Amain)
 [![codecov](https://codecov.io/gh/pdfarranger/pdfarranger/branch/main/graph/badge.svg)](https://codecov.io/gh/pdfarranger/pdfarranger)
 
-*pdfarranger* is a small python-gtk application, which helps the user to merge
+*PDF Arranger* is a small python-gtk application, which helps the user to merge
 or split pdf documents and rotate, crop and rearrange their pages using an
 interactive and intuitive graphical interface. It is a frontend for
 [pikepdf](https://github.com/pikepdf/pikepdf).
 
-*pdfarranger* is a fork of Konstantinos Poulios’s pdfshuffler
+*PDF Arranger* is a fork of Konstantinos Poulios’s pdfshuffler
 (see [Savannah](https://savannah.nongnu.org/projects/pdfshuffler) or
 [Sourceforge](http://sourceforge.net/projects/pdfshuffler)).
 It’s a humble attempt to make the project a bit more active.
@@ -37,7 +37,7 @@ lines.
 
 ## Install from source
 
-*pdfarranger* requires [pikepdf](https://github.com/pikepdf/pikepdf) >= 1.7.0, but pikepdf >= 1.15.1 is highly recommended.
+*PDF Arranger* requires [pikepdf](https://github.com/pikepdf/pikepdf) >= 1.7.0, but pikepdf >= 1.15.1 is highly recommended.
 pip will automatically install the latest pikepdf if there is no pikepdf installed on the system.
 
 **On Debian based distributions**
@@ -70,7 +70,7 @@ sudo pkg install devel/gettext devel/py-gobject3 devel/py-pip devel/py-python-di
 pip3 install --user --upgrade https://github.com/pdfarranger/pdfarranger/zipball/main
 ```
 
-In addition, *pdfarranger* supports image file import if [img2pdf](https://gitlab.mister-muffin.de/josch/img2pdf) is installed.
+In addition, *PDF Arranger* supports image file import if [img2pdf](https://gitlab.mister-muffin.de/josch/img2pdf) is installed.
 
 ## For developers
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,4 +1,4 @@
-This file aims at listing all GUI operation one should do to test the whole pdfarranger
+This file aims at listing all GUI operation one should do to test the whole PDF Arranger
 source code. Those tests must currently be done manually. May one day, they'll
 be done with [Dogtail](https://gitlab.com/dogtail/dogtail) or another GUI testing framework.
 
@@ -28,7 +28,7 @@ possible. This list was created using
 
 -   Move one page using drag and drop
 
--   Cut / paste within same pdfarranger instance
+-   Cut / paste within same PDF Arranger instance
 
 -   Save As
 
@@ -40,13 +40,13 @@ possible. This list was created using
 
 -   Drag a PDF file from a file explorer
 
--   Copy a PDF file from another pdfarranger instance and paste it interleaved
+-   Copy a PDF file from another PDF Arranger instance and paste it interleaved
 
 -   Select all pages, copy then paste odd
 
 -   Select even page, then invert selection
 
--   Drag a PDF file from a pdfarranger to a other pdfarranger instance
+-   Drag a PDF file from a PDF Arranger to a other PDF Arranger instance
 
 -   Duplicate a page
 

--- a/Win32.md
+++ b/Win32.md
@@ -1,4 +1,4 @@
-# pdfarranger on Windows
+# PDF Arranger on Windows
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ pip install --user https://launchpad.net/python-distutils-extra/trunk/2.39/+down
 /mingw64/bin/python3 -m pip install --user keyboard img2pdf pikepdf https://github.com/jeromerobert/cx_Freeze/zipball/pdfarranger
 ```
 
-Get the pdfarranger sources from a MSYS2 shell:
+Get the PDF Arranger sources from a MSYS2 shell:
 
 ```
 git clone https://github.com/pdfarranger/pdfarranger.git
@@ -53,7 +53,7 @@ create a pdfarranger installer in Wine you must first install the required mingw
 on a real Windows box. Then copy the MSYS2 `/mingw64` to Linux and run installation process with
 `wine /path/to/mingw64/bin/python3` instead of `/mingw64/bin/python3`.
 
-To run the pdfarranger in Wine you may have to:
+To run the PDF Arranger in Wine you may have to:
 
 ```
 unset $(env |grep ^XDG_ | cut -d= -f1)

--- a/data/com.github.jeromerobert.pdfarranger.metainfo.xml
+++ b/data/com.github.jeromerobert.pdfarranger.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
 <!--
-This file is part of pdfarranger which is released under the GNU General Public
+This file is part of PDF Arranger which is released under the GNU General Public
 License version 3 or later.
 See file COPYING or go to <http://www.gnu.org/licenses/> for full license details.
 -->
@@ -14,7 +14,7 @@ See file COPYING or go to <http://www.gnu.org/licenses/> for full license detail
   <content_rating type="oars-1.1"/>
   <description>
     <p>
-      pdfarranger is a small application, which helps the user to merge or split pdf
+      PDF Arranger is a small application, which helps the user to merge or split pdf
       documents and rotate, crop and rearrange their pages using an interactive and
       intuitive graphical interface.
       It is a frontend for pikepdf.

--- a/data/menu.ui
+++ b/data/menu.ui
@@ -2,20 +2,20 @@
 <!--
 Copyright (C) 2020 Jerome Robert
 
-This file is part of PDF-Arranger.
+This file is part of PDF Arranger.
 
-PDF-Arranger is free software: you can redistribute it and/or modify
+PDF Arranger is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-PDF-Arranger is distributed in the hope that it will be useful,
+PDF Arranger is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
+along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
   <menu id="main_menu">

--- a/data/pdfarranger.ui
+++ b/data/pdfarranger.ui
@@ -3,20 +3,20 @@
 <!--
 Copyright (C) 2020 Jerome Robert
 
-This file is part of PDF-Arranger.
+This file is part of PDF Arranger.
 
-PDF-Arranger is free software: you can redistribute it and/or modify
+PDF Arranger is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-PDF-Arranger is distributed in the hope that it will be useful,
+PDF Arranger is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
+along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>

--- a/doc/pdfarranger.1
+++ b/doc/pdfarranger.1
@@ -1,17 +1,17 @@
 .TH PDFARRANGER 1 "May 2019" "version 1.2" "User Manuals"
 .SH "NAME"
-PDF-Arranger \- Application for PDF Merging, Rearranging, Splitting, and Cropping
+PDF Arranger \- Application for PDF Merging, Rearranging, Splitting, and Cropping
 .SH "SYNOPSIS"
 .B pdfarranger [file1] [file2] ...
 .SH "DESCRIPTION"
-.B PDF-Arranger
+.B PDF Arranger
 is a small python-gtk application, which helps
 the user to merge or split pdf documents and rearrange their
 pages using an interactive and intuitive graphical interface.
 In the current version, page rotation and cropping is also
-supported. PDF-Arranger is a frontend for pikepdf.
+supported. PDF Arranger is a frontend for pikepdf.
 .SH "OPTIONS"
-Currently PDF-Arranger doesn't receive any options.
+Currently PDF Arranger doesn't receive any options.
 .SH "FILES"
 $HOME/.config/pdfarranger/config.ini
 .SH "ENVIRONMENT"

--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -195,7 +195,7 @@ class PasswordDialog(Gtk.Dialog):
             ),
         )
         self.set_default_response(Gtk.ResponseType.OK)
-        bottommsg = _("The password will be remembered until you close PDF-Arranger.")
+        bottommsg = _("The password will be remembered until you close PDF Arranger.")
         topmsg = _("The document “{}” is locked and requires a password before it can be opened.")
         label = Gtk.Label(label=topmsg.format(filename))
         label.set_max_width_chars(len(bottommsg)-6)

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -156,7 +156,7 @@ def export(input_files, pages, file_out, mode, mdata):
                 _report_pikepdf_err = False
                 traceback.print_exc()
                 print("Current pikepdf version {}, required pikepdf version "
-                      "1.7.0 or greater. Continuing but pdfarranger will not "
+                      "1.7.0 or greater. Continuing but PDF Arranger will not "
                       "work properly.".format(pikepdf.__version__),
                       file=sys.stderr)
         if angle != 0:

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -26,7 +26,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/cs.po
+++ b/po/cs.po
@@ -30,7 +30,7 @@ msgid "Password required"
 msgstr "Je vyžadováno heslo"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr "Heslo bude zapamatováno, dokud neukončíte program PDF Arranger."
 
 #: pdfarranger/core.py:187

--- a/po/de.po
+++ b/po/de.po
@@ -29,8 +29,8 @@ msgid "Password required"
 msgstr "Passwort wird benötigt"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "Das Passwort wird gespeichert bis PDF-Arranger geschlossen wird."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "Das Passwort wird gespeichert bis PDF Arranger geschlossen wird."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/el.po
+++ b/po/el.po
@@ -29,7 +29,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/es.po
+++ b/po/es.po
@@ -31,8 +31,8 @@ msgid "Password required"
 msgstr "Se requiere contraseña"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "La contraseña se guarda hasta que cierra PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "La contraseña se guarda hasta que cierra PDF Arranger."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -27,7 +27,7 @@ msgid "Password required"
 msgstr "Salasana tarvitaan"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr "Salasana pysyy muistissa kunnes ohjelma suljetaan."
 
 #: pdfarranger/core.py:187

--- a/po/fr.po
+++ b/po/fr.po
@@ -33,8 +33,8 @@ msgid "Password required"
 msgstr "Mot de passe requis"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "Le mot de passe sera mémorisé jusqu’à la fermeture de PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "Le mot de passe sera mémorisé jusqu’à la fermeture de PDF Arranger."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -28,7 +28,7 @@ msgid "Password required"
 msgstr "Zahtijeva lozinku"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr "Lozinka će se zapamtiti, sve dok se ne zatvori PDF uređivač."
 
 #: pdfarranger/core.py:187

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,4 +1,4 @@
-# This file is part of PDF-Arranger which is released under the GNU General
+# This file is part of PDF Arranger which is released under the GNU General
 # Public License version 3 or later.
 # See file COPYING or go to <http://www.gnu.org/licenses/> for full license details.
 # Translators:
@@ -23,7 +23,7 @@ msgid "Password required"
 msgstr "Jelszó szükséges"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr "A jelszó mindaddig emlékezetes marad, amíg bezárja a PDF-rendezőt"
 
 #: pdfarranger/core.py:187

--- a/po/id.po
+++ b/po/id.po
@@ -27,7 +27,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/it.po
+++ b/po/it.po
@@ -26,8 +26,8 @@ msgid "Password required"
 msgstr "Password richiesta"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "La password verrà ricordata fino alla chiusura di PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "La password verrà ricordata fino alla chiusura di PDF Arranger."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -28,8 +28,8 @@ msgid "Password required"
 msgstr "パスワードが必要です"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "パスワードは PDF-Arranger を閉じるまで記憶されます。"
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "パスワードは PDF Arranger を閉じるまで記憶されます。"
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -31,8 +31,8 @@ msgid "Password required"
 msgstr "Wachtwoord vereist"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "PDF-Arranger onthoudt het wachtwoord totdat je afsluit."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "PDF Arranger onthoudt het wachtwoord totdat je afsluit."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/pdfarranger.pot
+++ b/po/pdfarranger.pot
@@ -26,7 +26,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -33,7 +33,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -27,8 +27,8 @@ msgid "Password required"
 msgstr "Senha obrigatória"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "A senha será lembrada até que você feche o PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "A senha será lembrada até que você feche o PDF Arranger."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -29,8 +29,8 @@ msgid "Password required"
 msgstr "Requer palavra-passe"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "PDF-Arranger apenas irá memorizar a palavra-passe para esta sessão."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "PDF Arranger apenas irá memorizar a palavra-passe para esta sessão."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -25,7 +25,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/sv.po
+++ b/po/sv.po
@@ -27,7 +27,7 @@ msgid "Password required"
 msgstr "Lösenord krävs"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr "Lösenordet kommer att vara sparat tills du stänger PDF Arranger."
 
 #: pdfarranger/core.py:187

--- a/po/tr.po
+++ b/po/tr.po
@@ -28,8 +28,8 @@ msgid "Password required"
 msgstr "Parola gerekli"
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
-msgstr "Parola, siz PDF-Arrangerʼi kapatana dek anımsanacak."
+msgid "The password will be remembered until you close PDF Arranger."
+msgstr "Parola, siz PDF Arrangerʼi kapatana dek anımsanacak."
 
 #: pdfarranger/core.py:187
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -29,7 +29,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -26,7 +26,7 @@ msgid "Password required"
 msgstr ""
 
 #: pdfarranger/core.py:186
-msgid "The password will be remembered until you close PDF-Arranger."
+msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
 #: pdfarranger/core.py:187


### PR DESCRIPTION
We had at least three ways of spelling "pdfarranger", "PDF Arranger" or "PDF-Arranger".

This PR tries to normalize that in just two forms: PDF Arranger as the official name in documentation and all UI strings and pdfarranger as package name, filename, in various parts of the source code and source code comments.

This is just a suggestion based on the current usage (PDF Arranger is used in the most important places like the window title and in the desktop file.) I can easily replace PDF Arranger by PDF-Arranger or go pdfarranger all the way if that would be preferred.