### PR TITLE
Add workaround for pikepdf < 2.6.0

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -165,12 +165,20 @@ def export(input_files, pages, file_out, mode, mdata):
         if cropped:
             new_page.MediaBox = cropped
         new_page = _scale(pdf_output, new_page, row.scale)
+
+        # Workraround for pikepdf < 2.7.0
+        # https://github.com/pikepdf/pikepdf/issues/174
+        new_page = pdf_output.make_indirect(new_page)
+
         pdf_output.pages.append(new_page)
 
     if exportmode in ['ALL_TO_MULTIPLE', 'SELECTED_TO_MULTIPLE']:
         for n, page in enumerate(pdf_output.pages):
             outpdf = pikepdf.Pdf.new()
             _set_meta(mdata, pdf_input, outpdf)
+            # needed to add this, probably related to pikepdf < 2.7.0 workaround
+            page = outpdf.copy_foreign(page)
+            # works without make_indirect as already applied to this page
             outpdf.pages.append(page)
             outname = file_out
             parts = file_out.rsplit('.', 1)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -168,7 +168,8 @@ def malloc_trim():
     """Release free memory from the heap."""
     if os.name == 'nt':
         return
-    if mtrim := malloc_trim_available():
+    mtrim = malloc_trim_available()
+    if mtrim:
         mtrim()
 
 


### PR DESCRIPTION
See: https://github.com/pikepdf/pikepdf/issues/174
See: https://github.com/pdfarranger/pdfarranger/issues/427

(Also removed the walrus operator for compatibility with older python versions.)

How do you feel about pushing this out as a bugfix release in the next days?