### PR TITLE
Render more sharp thumbnails (in some cases)

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -441,11 +441,10 @@ class PDFRenderer(threading.Thread, GObject.GObject):
         w, h = page.get_size()
         scale = p.scale / self.resample
         thumbnail = cairo.ImageSurface(
-            cairo.FORMAT_ARGB32, int(w * scale), int(h * scale)
+            cairo.FORMAT_ARGB32, int(0.5 + w * scale), int(0.5 + h * scale)
         )
         cr = cairo.Context(thumbnail)
-        if scale != 1.0:
-            cr.scale(scale, scale)
+        cr.scale(int(0.5 + w * scale) / w, int(0.5 + h * scale) / h)
         with pdfdoc.render_lock:
             page.render(cr)
         GObject.idle_add(

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -514,7 +514,7 @@ class PdfArranger(Gtk.Application):
         GObject.signal_new('update_thumbnail', PDFRenderer,
                            GObject.SignalFlags.RUN_FIRST, None,
                            [GObject.TYPE_INT, GObject.TYPE_PYOBJECT,
-                            GObject.TYPE_FLOAT])
+                            GObject.TYPE_PYOBJECT])
         self.set_unsaved(False)
         self.__create_actions()
         self.__create_menus()


### PR DESCRIPTION

* Set cell size correctly so that thumbnail is not (in some cases)
  scaled.
* With GObject.TYPE_FLOAT the resample value emitted from rendering
  thread will have changed a bit when it is received in update_
  thumbnail. With GObject.TYPE_PYOBJECT it is transferred unaltered.
* The issue that cells are (sometimes) moving up or down while
  rendering is also eliminated here.

Here are two examples. Before commit to the left and after to the right. I see same result with many pdfs.

![unsharp-sharp](https://user-images.githubusercontent.com/60842129/111073236-a6294880-84e6-11eb-8104-5e19a5c888e9.png)





![picture2](https://user-images.githubusercontent.com/60842129/111073463-7af32900-84e7-11eb-9046-e7870cada9af.png)
