### PR TITLE
Fix thumbnail size during scale transition

### DIFF
--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -43,6 +43,7 @@ def scale(model, selection, factor):
         f = min(f, 14400 / page.size[0], 14400 / page.size[1])
         if page.scale != f:
             changed = True
+        page.resample = page.resample * f / page.scale
         page.scale = f
         model.set_value(it, 0, page)
     return changed


### PR DESCRIPTION
When page format is changed the thumbnail will not have the right size
until the thumbnail is re-rendered. This commit changes resample so
that thumbnail is scaled until it is re-rendered.