### PR TITLE
Use visible size when creating blank pages

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -350,7 +350,7 @@ class PdfArranger(Gtk.Application):
         selection.sort()
         model = self.iconview.get_model()
         if len(selection) > 0:
-            size = model[selection[-1]][0].size
+            size = model[selection[-1]][0].size_in_points()
         page_size = croputils.BlankPageDialog(size, self.window).run_get()
         if page_size is not None:
             adder = PageAdder(self)


### PR DESCRIPTION
With this fix `create blank page` considers crops and scaling when suggesting a page size.

Behavior so far: The suggested size is the original page size, not the visible area.

![image](https://user-images.githubusercontent.com/17718454/112955447-b88abf80-913f-11eb-8ff4-0f344fadd7bb.png)

