### PR TITLE
Don't trash table of contents and links on export

### DIFF
--- a/tests/exporter/outlines.pdf
+++ b/tests/exporter/outlines.pdf
@@ -1,0 +1,898 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Outlines 2 0 R
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+>>
+endobj
+
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Count 4
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Resources 10 0 R
+  /Type /Pages
+>>
+endobj
+
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 12 0 R
+  /Title (Page 4)
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /Annots [
+    13 0 R
+    14 0 R
+    15 0 R
+    16 0 R
+  ]
+  /Contents 17 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources 10 0 R
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 7 0
+7 0 obj
+<<
+  /Annots [
+    19 0 R
+    20 0 R
+    21 0 R
+    22 0 R
+  ]
+  /Contents 23 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources 10 0 R
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 8 0
+8 0 obj
+<<
+  /Annots [
+    25 0 R
+    26 0 R
+    27 0 R
+    28 0 R
+  ]
+  /Contents 29 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources 10 0 R
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 9 0
+9 0 obj
+<<
+  /Annots [
+    31 0 R
+    32 0 R
+    33 0 R
+    34 0 R
+  ]
+  /Contents 35 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources 10 0 R
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 10 0
+10 0 obj
+<<
+  /Font 37 0 R
+  /ProcSet [
+    /PDF
+    /Text
+  ]
+>>
+endobj
+
+%% Original object ID: 11 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 12 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 12 0
+12 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 3)
+>>
+endobj
+
+%% Original object ID: 13 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+16 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 17 0
+17 0 obj
+<<
+  /Length 18 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 1)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+18 0 obj
+314
+endobj
+
+%% Original object ID: 19 0
+19 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 20 0
+20 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 21 0
+21 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 22 0
+22 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 23 0
+23 0 obj
+<<
+  /Length 24 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+24 0 obj
+314
+endobj
+
+%% Original object ID: 25 0
+25 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+27 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+28 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 29 0
+29 0 obj
+<<
+  /Length 30 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+30 0 obj
+314
+endobj
+
+%% Original object ID: 31 0
+31 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 33 0
+33 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+34 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 4
+%% Original object ID: 35 0
+35 0 obj
+<<
+  /Length 36 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+36 0 obj
+314
+endobj
+
+%% Original object ID: 37 0
+37 0 obj
+<<
+  /F2 38 0 R
+>>
+endobj
+
+%% Original object ID: 38 0
+38 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+xref
+0 39
+0000000000 65535 f 
+0000000052 00000 n 
+0000000151 00000 n 
+0000000240 00000 n 
+0000000435 00000 n 
+0000000604 00000 n 
+0000000783 00000 n 
+0000001086 00000 n 
+0000001389 00000 n 
+0000001692 00000 n 
+0000001986 00000 n 
+0000002088 00000 n 
+0000002273 00000 n 
+0000002458 00000 n 
+0000002680 00000 n 
+0000002902 00000 n 
+0000003124 00000 n 
+0000003369 00000 n 
+0000003740 00000 n 
+0000003789 00000 n 
+0000004011 00000 n 
+0000004233 00000 n 
+0000004455 00000 n 
+0000004700 00000 n 
+0000005071 00000 n 
+0000005120 00000 n 
+0000005342 00000 n 
+0000005564 00000 n 
+0000005786 00000 n 
+0000006031 00000 n 
+0000006402 00000 n 
+0000006451 00000 n 
+0000006673 00000 n 
+0000006895 00000 n 
+0000007117 00000 n 
+0000007362 00000 n 
+0000007733 00000 n 
+0000007782 00000 n 
+0000007846 00000 n 
+trailer <<
+  /DocChecksum /C0B7B02D232A8DFB9E661438F22D70FD
+  /Root 1 0 R
+  /Size 39
+  /ID [<747ec04935be9a8770701ac5cb22ab64><b60b5640649f8dafcfb8e4f8c6280d3c>]
+>>
+startxref
+7925
+%%EOF

--- a/tests/exporter/test10_8_out.pdf
+++ b/tests/exporter/test10_8_out.pdf
@@ -1,0 +1,198 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /8sRcI0wNNmuxkKJbRC2Bng 6 0 R
+      /YnzVCh_Yx1K7bcTlw2nHGQ 8 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 33 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q
+q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+Q
+q
+0.5 0 0 0.5 306 198 cm
+/8sRcI0wNNmuxkKJbRC2Bng Do
+Q
+Q
+q
+0.5 0 0 0.5 0 198 cm
+/YnzVCh_Yx1K7bcTlw2nHGQ Do
+Q
+endstream
+endobj
+
+5 0 obj
+166
+endobj
+
+%% Original object ID: 24 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+7 0 obj
+101
+endobj
+
+%% Original object ID: 29 0
+8 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 9 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+9 0 obj
+101
+endobj
+
+%% Original object ID: 22 0
+10 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000537 00000 n 
+0000000758 00000 n 
+0000000806 00000 n 
+0000001192 00000 n 
+0000001240 00000 n 
+0000001626 00000 n 
+0000001674 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 11
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+1779
+%%EOF

--- a/tests/exporter/test11_8_out.pdf
+++ b/tests/exporter/test11_8_out.pdf
@@ -1,0 +1,198 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /WWb94uPe7eGTem5LCaQlAw 6 0 R
+      /hYsD8islTtUIaWUcZbeF0Q 8 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 33 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q
+q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+Q
+q
+0.5 0 0 0.5 153 0 cm
+/hYsD8islTtUIaWUcZbeF0Q Do
+Q
+Q
+q
+0.5 0 0 0.5 153 396 cm
+/WWb94uPe7eGTem5LCaQlAw Do
+Q
+endstream
+endobj
+
+5 0 obj
+166
+endobj
+
+%% Original object ID: 29 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+7 0 obj
+101
+endobj
+
+%% Original object ID: 24 0
+8 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 9 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+9 0 obj
+101
+endobj
+
+%% Original object ID: 22 0
+10 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000537 00000 n 
+0000000758 00000 n 
+0000000806 00000 n 
+0000001192 00000 n 
+0000001240 00000 n 
+0000001626 00000 n 
+0000001674 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 11
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+1779
+%%EOF

--- a/tests/exporter/test12_8_out.pdf
+++ b/tests/exporter/test12_8_out.pdf
@@ -1,0 +1,484 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 7 0
+3 0 obj
+<<
+  /Annots [
+    5 0 R
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Contents 10 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 12 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 23 0
+4 0 obj
+<<
+  /Annots [
+    13 0 R
+    14 0 R
+    15 0 R
+    16 0 R
+    17 0 R
+  ]
+  /Contents 10 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 12 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 12 0
+5 0 obj
+<<
+  /Border [
+    0
+    0
+    5
+  ]
+  /C [
+    1
+    0.6666666667
+    0
+  ]
+  /CA 0.8
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    71.32546
+    726.063953
+    125.166469
+    745.507135
+  ]
+  /Subtype /Square
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 13 0
+6 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /QuadPoints [
+    92.0276617597
+    675.0934997344
+    138.0414926395
+    675.0934997344
+    92.0276617597
+    659.2766126267
+    138.0414926395
+    659.2766126267
+  ]
+  /Rect [
+    91.862752
+    659.401616
+    137.932894
+    675.233921
+  ]
+  /Subtype /Highlight
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+7 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0069006e006c0069006e00650020006e006f00740065>
+  /F 20
+  /IT /FreeText
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    57.17138
+    549.131001
+    107.404487
+    563.852267
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+8 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /CA 1
+  /Contents <feff0057007200690074006500740079007000650072000a>
+  /F 20
+  /IT /FreeTextTypeWriter
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    56.338788
+    455.430421
+    112.122513
+    478.580027
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+9 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0070006f0070002d00750070>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    61.611876
+    405.70976
+    79.470994
+    423.583599
+  ]
+  /Subtype /Text
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 17 0
+10 0 obj
+<<
+  /Length 11 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+56.8 732.589 Td /F1 8 Tf(    Rectangle) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+92.3 663.589 Td /F1 8 Tf (Highlight) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 566.989 Td /F1 8 Tf (inline note) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 539.389 Td /F1 8 Tf (----------) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 484.189 Td /F1 8 Tf (Typewriter) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 428.989 Td /F1 8 Tf (Popup) Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+11 0 obj
+400
+endobj
+
+%% Original object ID: 22 0
+12 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 24 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    5
+  ]
+  /C [
+    1
+    0.6666666667
+    0
+  ]
+  /CA 0.8
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    71.32546
+    726.063953
+    125.166469
+    745.507135
+  ]
+  /Subtype /Square
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 25 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /QuadPoints [
+    92.0276617597
+    675.0934997344
+    138.0414926395
+    675.0934997344
+    92.0276617597
+    659.2766126267
+    138.0414926395
+    659.2766126267
+  ]
+  /Rect [
+    91.862752
+    659.401616
+    137.932894
+    675.233921
+  ]
+  /Subtype /Highlight
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0069006e006c0069006e00650020006e006f00740065>
+  /F 20
+  /IT /FreeText
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    57.17138
+    549.131001
+    107.404487
+    563.852267
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+16 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /CA 1
+  /Contents <feff0057007200690074006500740079007000650072000a>
+  /F 20
+  /IT /FreeTextTypeWriter
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    56.338788
+    455.430421
+    112.122513
+    478.580027
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+17 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0070006f0070002d00750070>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    61.611876
+    405.70976
+    79.470994
+    423.583599
+  ]
+  /Subtype /Text
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+xref
+0 18
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000587 00000 n 
+0000000917 00000 n 
+0000001234 00000 n 
+0000001712 00000 n 
+0000002086 00000 n 
+0000002442 00000 n 
+0000002790 00000 n 
+0000003247 00000 n 
+0000003296 00000 n 
+0000003429 00000 n 
+0000003747 00000 n 
+0000004226 00000 n 
+0000004601 00000 n 
+0000004958 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 18
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+5256
+%%EOF

--- a/tests/exporter/test13_8_out.pdf
+++ b/tests/exporter/test13_8_out.pdf
@@ -1,0 +1,484 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 7 0
+3 0 obj
+<<
+  /Annots [
+    5 0 R
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Contents 10 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 12 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 90
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 23 0
+4 0 obj
+<<
+  /Annots [
+    13 0 R
+    14 0 R
+    15 0 R
+    16 0 R
+    17 0 R
+  ]
+  /Contents 10 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 12 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 180
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 12 0
+5 0 obj
+<<
+  /Border [
+    0
+    0
+    5
+  ]
+  /C [
+    1
+    0.6666666667
+    0
+  ]
+  /CA 0.8
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    71.32546
+    726.063953
+    125.166469
+    745.507135
+  ]
+  /Subtype /Square
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 13 0
+6 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /QuadPoints [
+    92.0276617597
+    675.0934997344
+    138.0414926395
+    675.0934997344
+    92.0276617597
+    659.2766126267
+    138.0414926395
+    659.2766126267
+  ]
+  /Rect [
+    91.862752
+    659.401616
+    137.932894
+    675.233921
+  ]
+  /Subtype /Highlight
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+7 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0069006e006c0069006e00650020006e006f00740065>
+  /F 20
+  /IT /FreeText
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    57.17138
+    549.131001
+    107.404487
+    563.852267
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+8 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /CA 1
+  /Contents <feff0057007200690074006500740079007000650072000a>
+  /F 20
+  /IT /FreeTextTypeWriter
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    56.338788
+    455.430421
+    112.122513
+    478.580027
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+9 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0070006f0070002d00750070>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    61.611876
+    405.70976
+    79.470994
+    423.583599
+  ]
+  /Subtype /Text
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 17 0
+10 0 obj
+<<
+  /Length 11 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+56.8 732.589 Td /F1 8 Tf(    Rectangle) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+92.3 663.589 Td /F1 8 Tf (Highlight) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 566.989 Td /F1 8 Tf (inline note) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 539.389 Td /F1 8 Tf (----------) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 484.189 Td /F1 8 Tf (Typewriter) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 428.989 Td /F1 8 Tf (Popup) Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+11 0 obj
+400
+endobj
+
+%% Original object ID: 22 0
+12 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 24 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    5
+  ]
+  /C [
+    1
+    0.6666666667
+    0
+  ]
+  /CA 0.8
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    71.32546
+    726.063953
+    125.166469
+    745.507135
+  ]
+  /Subtype /Square
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 25 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /QuadPoints [
+    92.0276617597
+    675.0934997344
+    138.0414926395
+    675.0934997344
+    92.0276617597
+    659.2766126267
+    138.0414926395
+    659.2766126267
+  ]
+  /Rect [
+    91.862752
+    659.401616
+    137.932894
+    675.233921
+  ]
+  /Subtype /Highlight
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0069006e006c0069006e00650020006e006f00740065>
+  /F 20
+  /IT /FreeText
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    57.17138
+    549.131001
+    107.404487
+    563.852267
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+16 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /CA 1
+  /Contents <feff0057007200690074006500740079007000650072000a>
+  /F 20
+  /IT /FreeTextTypeWriter
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    56.338788
+    455.430421
+    112.122513
+    478.580027
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+17 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0070006f0070002d00750070>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    61.611876
+    405.70976
+    79.470994
+    423.583599
+  ]
+  /Subtype /Text
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+xref
+0 18
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000588 00000 n 
+0000000920 00000 n 
+0000001237 00000 n 
+0000001715 00000 n 
+0000002089 00000 n 
+0000002445 00000 n 
+0000002793 00000 n 
+0000003250 00000 n 
+0000003299 00000 n 
+0000003432 00000 n 
+0000003750 00000 n 
+0000004229 00000 n 
+0000004604 00000 n 
+0000004961 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 18
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+5259
+%%EOF

--- a/tests/exporter/test14_8_out.pdf
+++ b/tests/exporter/test14_8_out.pdf
@@ -1,0 +1,162 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 7 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    153
+    198
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /p2 6 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 25 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q 0.25 0 0 0.25 0 0 cm /p2 Do Q
+endstream
+endobj
+
+%QDF: ignore_newline
+5 0 obj
+31
+endobj
+
+%% Original object ID: 24 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 8 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+56.8 732.589 Td /F1 8 Tf(    Rectangle) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+92.3 663.589 Td /F1 8 Tf (Highlight) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 566.989 Td /F1 8 Tf (inline note) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 539.389 Td /F1 8 Tf (----------) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 484.189 Td /F1 8 Tf (Typewriter) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 428.989 Td /F1 8 Tf (Popup) Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+7 0 obj
+400
+endobj
+
+%% Original object ID: 22 0
+8 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000481 00000 n 
+0000000589 00000 n 
+0000000636 00000 n 
+0000001320 00000 n 
+0000001368 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 9
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+1472
+%%EOF

--- a/tests/exporter/test15_8_out.pdf
+++ b/tests/exporter/test15_8_out.pdf
@@ -1,0 +1,290 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 7 0
+3 0 obj
+<<
+  /Annots [
+    4 0 R
+    5 0 R
+    6 0 R
+    7 0 R
+    8 0 R
+  ]
+  /Contents 9 0 R
+  /MediaBox [
+    30.6
+    237.6
+    566.1
+    633.6
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 11 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 12 0
+4 0 obj
+<<
+  /Border [
+    0
+    0
+    5
+  ]
+  /C [
+    1
+    0.6666666667
+    0
+  ]
+  /CA 0.8
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    71.32546
+    726.063953
+    125.166469
+    745.507135
+  ]
+  /Subtype /Square
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 13 0
+5 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff>
+  /F 4
+  /P 3 0 R
+  /QuadPoints [
+    92.0276617597
+    675.0934997344
+    138.0414926395
+    675.0934997344
+    92.0276617597
+    659.2766126267
+    138.0414926395
+    659.2766126267
+  ]
+  /Rect [
+    91.862752
+    659.401616
+    137.932894
+    675.233921
+  ]
+  /Subtype /Highlight
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+6 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0069006e006c0069006e00650020006e006f00740065>
+  /F 20
+  /IT /FreeText
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    57.17138
+    549.131001
+    107.404487
+    563.852267
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+7 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /CA 1
+  /Contents <feff0057007200690074006500740079007000650072000a>
+  /F 20
+  /IT /FreeTextTypeWriter
+  /P 3 0 R
+  /Q 0
+  /Rect [
+    56.338788
+    455.430421
+    112.122513
+    478.580027
+  ]
+  /Subtype /FreeText
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+8 0 obj
+<<
+  /Border [
+    0
+    0
+    1
+  ]
+  /C [
+    1
+    1
+    0
+  ]
+  /CA 1
+  /Contents <feff0070006f0070002d00750070>
+  /F 4
+  /P 3 0 R
+  /Rect [
+    61.611876
+    405.70976
+    79.470994
+    423.583599
+  ]
+  /Subtype /Text
+  /T <feff006d0061006e0066007200650064>
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 17 0
+9 0 obj
+<<
+  /Length 10 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+56.8 732.589 Td /F1 8 Tf(    Rectangle) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+92.3 663.589 Td /F1 8 Tf (Highlight) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 566.989 Td /F1 8 Tf (inline note) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 539.389 Td /F1 8 Tf (----------) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 484.189 Td /F1 8 Tf (Typewriter) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 428.989 Td /F1 8 Tf (Popup) Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+10 0 obj
+400
+endobj
+
+%% Original object ID: 22 0
+11 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 12
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000577 00000 n 
+0000000894 00000 n 
+0000001372 00000 n 
+0000001746 00000 n 
+0000002102 00000 n 
+0000002450 00000 n 
+0000002906 00000 n 
+0000002955 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 12
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+3060
+%%EOF

--- a/tests/exporter/test16_8_out.pdf
+++ b/tests/exporter/test16_8_out.pdf
@@ -1,0 +1,167 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /vIEzT8BeHS5C4PA_NQC44w 6 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 27 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+Q
+q
+1 0 0 1 0 0 cm
+/vIEzT8BeHS5C4PA_NQC44w Do
+Q
+endstream
+endobj
+
+5 0 obj
+102
+endobj
+
+%% Original object ID: 23 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 8 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+56.8 732.589 Td /F1 8 Tf(    Rectangle) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+92.3 663.589 Td /F1 8 Tf (Highlight) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 566.989 Td /F1 8 Tf (inline note) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 539.389 Td /F1 8 Tf (----------) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 484.189 Td /F1 8 Tf (Typewriter) Tj
+ET
+Q
+q 0 0 0 rg
+BT
+56.8 428.989 Td /F1 8 Tf (Popup) Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+7 0 obj
+400
+endobj
+
+%% Original object ID: 22 0
+8 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000501 00000 n 
+0000000658 00000 n 
+0000000706 00000 n 
+0000001390 00000 n 
+0000001438 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 9
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+1542
+%%EOF

--- a/tests/exporter/test17_8_out.pdf
+++ b/tests/exporter/test17_8_out.pdf
@@ -1,0 +1,106 @@
+%PDF-1.4
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Contents 7 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Length 6 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+6 0 obj
+52
+endobj
+
+%% Contents for page 2
+%% Original object ID: 6 0
+7 0 obj
+<<
+  /Length 8 0 R
+>>
+stream
+0 1 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+8 0 obj
+52
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000417 00000 n 
+0000000595 00000 n 
+0000000702 00000 n 
+0000000771 00000 n 
+0000000878 00000 n 
+trailer <<
+  /Root 1 0 R
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+897
+%%EOF

--- a/tests/exporter/test18_8_out.pdf
+++ b/tests/exporter/test18_8_out.pdf
@@ -1,0 +1,112 @@
+%PDF-1.7
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Extensions <<
+    /ADBE <<
+      /BaseVersion /1.7
+      /ExtensionLevel 8
+    >>
+  >>
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Contents 7 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Length 6 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+6 0 obj
+52
+endobj
+
+%% Contents for page 2
+%% Original object ID: 6 0
+7 0 obj
+<<
+  /Length 8 0 R
+>>
+stream
+0 1 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+8 0 obj
+52
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000223 00000 n 
+0000000342 00000 n 
+0000000507 00000 n 
+0000000685 00000 n 
+0000000792 00000 n 
+0000000861 00000 n 
+0000000968 00000 n 
+trailer <<
+  /Root 1 0 R
+  /ID [<5c10f271db390a18d2d37ba4379bb02f><31415926535897932384626433832795>]
+>>
+startxref
+987
+%%EOF

--- a/tests/exporter/test19_8_out.pdf
+++ b/tests/exporter/test19_8_out.pdf
@@ -1,0 +1,907 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Outlines 2 0 R
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+>>
+endobj
+
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Count 4
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 10 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 4)
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /Annots [
+    12 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+  ]
+  /Contents 16 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 7 0
+7 0 obj
+<<
+  /Annots [
+    19 0 R
+    20 0 R
+    21 0 R
+    22 0 R
+  ]
+  /Contents 23 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 8 0
+8 0 obj
+<<
+  /Annots [
+    25 0 R
+    26 0 R
+    27 0 R
+    28 0 R
+  ]
+  /Contents 29 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 9 0
+9 0 obj
+<<
+  /Annots [
+    31 0 R
+    32 0 R
+    33 0 R
+    34 0 R
+  ]
+  /Contents 35 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 11 0
+10 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 12 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 10 0 R
+  /Title (Page 3)
+>>
+endobj
+
+%% Original object ID: 13 0
+12 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 17 0
+16 0 obj
+<<
+  /Length 17 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 1)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+17 0 obj
+314
+endobj
+
+%% Original object ID: 38 0
+18 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 19 0
+19 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 20 0
+20 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 21 0
+21 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 22 0
+22 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 23 0
+23 0 obj
+<<
+  /Length 24 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+24 0 obj
+314
+endobj
+
+%% Original object ID: 25 0
+25 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+27 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+28 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 29 0
+29 0 obj
+<<
+  /Length 30 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+30 0 obj
+314
+endobj
+
+%% Original object ID: 31 0
+31 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 33 0
+33 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+34 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 4
+%% Original object ID: 35 0
+35 0 obj
+<<
+  /Length 36 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+36 0 obj
+314
+endobj
+
+xref
+0 37
+0000000000 65535 f 
+0000000052 00000 n 
+0000000151 00000 n 
+0000000240 00000 n 
+0000000369 00000 n 
+0000000538 00000 n 
+0000000717 00000 n 
+0000001114 00000 n 
+0000001511 00000 n 
+0000001908 00000 n 
+0000002296 00000 n 
+0000002481 00000 n 
+0000002666 00000 n 
+0000002888 00000 n 
+0000003110 00000 n 
+0000003332 00000 n 
+0000003577 00000 n 
+0000003948 00000 n 
+0000003997 00000 n 
+0000004104 00000 n 
+0000004326 00000 n 
+0000004548 00000 n 
+0000004770 00000 n 
+0000005015 00000 n 
+0000005386 00000 n 
+0000005435 00000 n 
+0000005657 00000 n 
+0000005879 00000 n 
+0000006101 00000 n 
+0000006346 00000 n 
+0000006717 00000 n 
+0000006766 00000 n 
+0000006988 00000 n 
+0000007210 00000 n 
+0000007432 00000 n 
+0000007677 00000 n 
+0000008048 00000 n 
+trailer <<
+  /DocChecksum /C0B7B02D232A8DFB9E661438F22D70FD
+  /Root 1 0 R
+  /Size 37
+  /ID [<747ec04935be9a8770701ac5cb22ab64><31415926535897932384626433832795>]
+>>
+startxref
+8069
+%%EOF

--- a/tests/exporter/test1_8_out.pdf
+++ b/tests/exporter/test1_8_out.pdf
@@ -1,0 +1,107 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Contents 7 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 10 0
+5 0 obj
+<<
+  /Length 6 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+6 0 obj
+52
+endobj
+
+%% Contents for page 2
+%% Original object ID: 11 0
+7 0 obj
+<<
+  /Length 8 0 R
+>>
+stream
+0 1 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+8 0 obj
+52
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000417 00000 n 
+0000000596 00000 n 
+0000000703 00000 n 
+0000000773 00000 n 
+0000000880 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 9
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+899
+%%EOF

--- a/tests/exporter/test20_8_out.pdf
+++ b/tests/exporter/test20_8_out.pdf
@@ -1,0 +1,907 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Outlines 2 0 R
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+>>
+endobj
+
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Count 4
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 10 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 4)
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 9 0
+6 0 obj
+<<
+  /Annots [
+    12 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+  ]
+  /Contents 16 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 7 0
+7 0 obj
+<<
+  /Annots [
+    19 0 R
+    20 0 R
+    21 0 R
+    22 0 R
+  ]
+  /Contents 23 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 6 0
+8 0 obj
+<<
+  /Annots [
+    25 0 R
+    26 0 R
+    27 0 R
+    28 0 R
+  ]
+  /Contents 29 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 8 0
+9 0 obj
+<<
+  /Annots [
+    31 0 R
+    32 0 R
+    33 0 R
+    34 0 R
+  ]
+  /Contents 35 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 11 0
+10 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 12 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 10 0 R
+  /Title (Page 3)
+>>
+endobj
+
+%% Original object ID: 31 0
+12 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 33 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 35 0
+16 0 obj
+<<
+  /Length 17 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+17 0 obj
+314
+endobj
+
+%% Original object ID: 38 0
+18 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 19 0
+19 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 20 0
+20 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 21 0
+21 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 22 0
+22 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 23 0
+23 0 obj
+<<
+  /Length 24 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+24 0 obj
+314
+endobj
+
+%% Original object ID: 13 0
+25 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+27 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+28 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 17 0
+29 0 obj
+<<
+  /Length 30 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 1)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+30 0 obj
+314
+endobj
+
+%% Original object ID: 25 0
+31 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+33 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+34 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 4
+%% Original object ID: 29 0
+35 0 obj
+<<
+  /Length 36 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+36 0 obj
+314
+endobj
+
+xref
+0 37
+0000000000 65535 f 
+0000000052 00000 n 
+0000000151 00000 n 
+0000000240 00000 n 
+0000000369 00000 n 
+0000000538 00000 n 
+0000000717 00000 n 
+0000001114 00000 n 
+0000001511 00000 n 
+0000001908 00000 n 
+0000002296 00000 n 
+0000002481 00000 n 
+0000002666 00000 n 
+0000002888 00000 n 
+0000003110 00000 n 
+0000003332 00000 n 
+0000003577 00000 n 
+0000003948 00000 n 
+0000003997 00000 n 
+0000004104 00000 n 
+0000004326 00000 n 
+0000004548 00000 n 
+0000004770 00000 n 
+0000005015 00000 n 
+0000005386 00000 n 
+0000005435 00000 n 
+0000005657 00000 n 
+0000005879 00000 n 
+0000006101 00000 n 
+0000006346 00000 n 
+0000006717 00000 n 
+0000006766 00000 n 
+0000006988 00000 n 
+0000007210 00000 n 
+0000007432 00000 n 
+0000007677 00000 n 
+0000008048 00000 n 
+trailer <<
+  /DocChecksum /C0B7B02D232A8DFB9E661438F22D70FD
+  /Root 1 0 R
+  /Size 37
+  /ID [<747ec04935be9a8770701ac5cb22ab64><31415926535897932384626433832795>]
+>>
+startxref
+8069
+%%EOF

--- a/tests/exporter/test21_8_out.pdf
+++ b/tests/exporter/test21_8_out.pdf
@@ -1,0 +1,866 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Outlines 2 0 R
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+>>
+endobj
+
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Count 4
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    10 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 12 0 R
+  /Title (Page 4)
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 9 0
+6 0 obj
+<<
+  /Annots [
+    13 0 R
+    14 0 R
+    15 0 R
+    16 0 R
+  ]
+  /Contents 17 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 19 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 7 0
+7 0 obj
+<<
+  /Annots [
+    20 0 R
+    21 0 R
+    22 0 R
+    23 0 R
+  ]
+  /Contents 24 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 19 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 8 0
+8 0 obj
+<<
+  /Annots [
+    26 0 R
+    27 0 R
+    28 0 R
+    29 0 R
+  ]
+  /Contents 30 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 19 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 40 0
+9 0 obj
+<<
+  /Annots [
+    32 0 R
+    33 0 R
+    34 0 R
+    35 0 R
+  ]
+  /Contents 17 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 19 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 6 0
+10 0 obj
+null
+endobj
+
+%% Original object ID: 11 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 12 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 12 0
+12 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 3)
+>>
+endobj
+
+%% Original object ID: 31 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    10 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 33 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+16 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 4
+%% Original object ID: 35 0
+17 0 obj
+<<
+  /Length 18 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+18 0 obj
+314
+endobj
+
+%% Original object ID: 38 0
+19 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 19 0
+20 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    10 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 20 0
+21 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 21 0
+22 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 22 0
+23 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 23 0
+24 0 obj
+<<
+  /Length 25 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+25 0 obj
+314
+endobj
+
+%% Original object ID: 25 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    10 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+27 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+28 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+29 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 29 0
+30 0 obj
+<<
+  /Length 31 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+31 0 obj
+314
+endobj
+
+%% Original object ID: 41 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    10 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 42 0
+33 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 43 0
+34 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 44 0
+35 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+xref
+0 36
+0000000000 65535 f 
+0000000052 00000 n 
+0000000151 00000 n 
+0000000240 00000 n 
+0000000369 00000 n 
+0000000539 00000 n 
+0000000718 00000 n 
+0000001115 00000 n 
+0000001512 00000 n 
+0000001910 00000 n 
+0000002297 00000 n 
+0000002347 00000 n 
+0000002532 00000 n 
+0000002717 00000 n 
+0000002940 00000 n 
+0000003162 00000 n 
+0000003384 00000 n 
+0000003629 00000 n 
+0000004000 00000 n 
+0000004049 00000 n 
+0000004156 00000 n 
+0000004379 00000 n 
+0000004601 00000 n 
+0000004823 00000 n 
+0000005068 00000 n 
+0000005439 00000 n 
+0000005488 00000 n 
+0000005711 00000 n 
+0000005933 00000 n 
+0000006155 00000 n 
+0000006400 00000 n 
+0000006771 00000 n 
+0000006820 00000 n 
+0000007043 00000 n 
+0000007265 00000 n 
+0000007487 00000 n 
+trailer <<
+  /DocChecksum /C0B7B02D232A8DFB9E661438F22D70FD
+  /Root 1 0 R
+  /Size 36
+  /ID [<747ec04935be9a8770701ac5cb22ab64><31415926535897932384626433832795>]
+>>
+startxref
+7681
+%%EOF

--- a/tests/exporter/test22_8_out.pdf
+++ b/tests/exporter/test22_8_out.pdf
@@ -1,0 +1,907 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Outlines 2 0 R
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+>>
+endobj
+
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Count 4
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 10 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 4)
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /Annots [
+    12 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+  ]
+  /Contents 16 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 7 0
+7 0 obj
+<<
+  /Annots [
+    19 0 R
+    20 0 R
+    21 0 R
+    22 0 R
+  ]
+  /Contents 23 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 90
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 8 0
+8 0 obj
+<<
+  /Annots [
+    25 0 R
+    26 0 R
+    27 0 R
+    28 0 R
+  ]
+  /Contents 29 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 180
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 9 0
+9 0 obj
+<<
+  /Annots [
+    31 0 R
+    32 0 R
+    33 0 R
+    34 0 R
+  ]
+  /Contents 35 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 270
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 11 0
+10 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 12 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 10 0 R
+  /Title (Page 3)
+>>
+endobj
+
+%% Original object ID: 13 0
+12 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 17 0
+16 0 obj
+<<
+  /Length 17 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 1)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+17 0 obj
+314
+endobj
+
+%% Original object ID: 38 0
+18 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 19 0
+19 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 20 0
+20 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 21 0
+21 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 22 0
+22 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 23 0
+23 0 obj
+<<
+  /Length 24 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+24 0 obj
+314
+endobj
+
+%% Original object ID: 25 0
+25 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+27 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+28 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 29 0
+29 0 obj
+<<
+  /Length 30 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+30 0 obj
+314
+endobj
+
+%% Original object ID: 31 0
+31 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 33 0
+33 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+34 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 4
+%% Original object ID: 35 0
+35 0 obj
+<<
+  /Length 36 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+36 0 obj
+314
+endobj
+
+xref
+0 37
+0000000000 65535 f 
+0000000052 00000 n 
+0000000151 00000 n 
+0000000240 00000 n 
+0000000369 00000 n 
+0000000538 00000 n 
+0000000717 00000 n 
+0000001114 00000 n 
+0000001512 00000 n 
+0000001911 00000 n 
+0000002301 00000 n 
+0000002486 00000 n 
+0000002671 00000 n 
+0000002893 00000 n 
+0000003115 00000 n 
+0000003337 00000 n 
+0000003582 00000 n 
+0000003953 00000 n 
+0000004002 00000 n 
+0000004109 00000 n 
+0000004331 00000 n 
+0000004553 00000 n 
+0000004775 00000 n 
+0000005020 00000 n 
+0000005391 00000 n 
+0000005440 00000 n 
+0000005662 00000 n 
+0000005884 00000 n 
+0000006106 00000 n 
+0000006351 00000 n 
+0000006722 00000 n 
+0000006771 00000 n 
+0000006993 00000 n 
+0000007215 00000 n 
+0000007437 00000 n 
+0000007682 00000 n 
+0000008053 00000 n 
+trailer <<
+  /DocChecksum /C0B7B02D232A8DFB9E661438F22D70FD
+  /Root 1 0 R
+  /Size 37
+  /ID [<747ec04935be9a8770701ac5cb22ab64><31415926535897932384626433832795>]
+>>
+startxref
+8074
+%%EOF

--- a/tests/exporter/test23_8_out.pdf
+++ b/tests/exporter/test23_8_out.pdf
@@ -1,0 +1,831 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Outlines 2 0 R
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+>>
+endobj
+
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Count 4
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 10 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 4)
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /Annots [
+    12 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+  ]
+  /Contents 16 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 7 0
+7 0 obj
+<<
+  /Contents 19 0 R
+  /MediaBox [
+    0
+    0
+    306
+    396
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /XObject <<
+      /p5 21 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 8 0
+8 0 obj
+<<
+  /Annots [
+    23 0 R
+    24 0 R
+    25 0 R
+    26 0 R
+  ]
+  /Contents 27 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 9 0
+9 0 obj
+<<
+  /Annots [
+    29 0 R
+    30 0 R
+    31 0 R
+    32 0 R
+  ]
+  /Contents 33 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 11 0
+10 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 12 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 10 0 R
+  /Title (Page 3)
+>>
+endobj
+
+%% Original object ID: 13 0
+12 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 14 0
+13 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 15 0
+14 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 16 0
+15 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 17 0
+16 0 obj
+<<
+  /Length 17 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 1)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+17 0 obj
+314
+endobj
+
+%% Original object ID: 38 0
+18 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 42 0
+19 0 obj
+<<
+  /Length 20 0 R
+>>
+stream
+q 0.5 0 0 0.5 0 0 cm /p5 Do Q
+endstream
+endobj
+
+%QDF: ignore_newline
+20 0 obj
+29
+endobj
+
+%% Original object ID: 41 0
+21 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F2 18 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 22 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+22 0 obj
+314
+endobj
+
+%% Original object ID: 25 0
+23 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 26 0
+24 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 27 0
+25 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 28 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 29 0
+27 0 obj
+<<
+  /Length 28 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+28 0 obj
+314
+endobj
+
+%% Original object ID: 31 0
+29 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+30 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 33 0
+31 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 4
+%% Original object ID: 35 0
+33 0 obj
+<<
+  /Length 34 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+endstream
+endobj
+
+34 0 obj
+314
+endobj
+
+xref
+0 35
+0000000000 65535 f 
+0000000052 00000 n 
+0000000151 00000 n 
+0000000240 00000 n 
+0000000369 00000 n 
+0000000538 00000 n 
+0000000717 00000 n 
+0000001114 00000 n 
+0000001341 00000 n 
+0000001738 00000 n 
+0000002126 00000 n 
+0000002311 00000 n 
+0000002496 00000 n 
+0000002718 00000 n 
+0000002940 00000 n 
+0000003162 00000 n 
+0000003407 00000 n 
+0000003778 00000 n 
+0000003827 00000 n 
+0000003957 00000 n 
+0000004065 00000 n 
+0000004113 00000 n 
+0000004783 00000 n 
+0000004832 00000 n 
+0000005054 00000 n 
+0000005276 00000 n 
+0000005498 00000 n 
+0000005743 00000 n 
+0000006114 00000 n 
+0000006163 00000 n 
+0000006385 00000 n 
+0000006607 00000 n 
+0000006829 00000 n 
+0000007074 00000 n 
+0000007445 00000 n 
+trailer <<
+  /DocChecksum /C0B7B02D232A8DFB9E661438F22D70FD
+  /Root 1 0 R
+  /Size 35
+  /ID [<747ec04935be9a8770701ac5cb22ab64><31415926535897932384626433832795>]
+>>
+startxref
+7466
+%%EOF

--- a/tests/exporter/test2_8_out.pdf
+++ b/tests/exporter/test2_8_out.pdf
@@ -1,0 +1,107 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 90
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Contents 7 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 180
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 10 0
+5 0 obj
+<<
+  /Length 6 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+6 0 obj
+52
+endobj
+
+%% Contents for page 2
+%% Original object ID: 11 0
+7 0 obj
+<<
+  /Length 8 0 R
+>>
+stream
+0 1 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+8 0 obj
+52
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000418 00000 n 
+0000000599 00000 n 
+0000000706 00000 n 
+0000000776 00000 n 
+0000000883 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 9
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+902
+%%EOF

--- a/tests/exporter/test3_8_out.pdf
+++ b/tests/exporter/test3_8_out.pdf
@@ -1,0 +1,90 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 5 0
+3 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 180
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 23 0
+4 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Rotate 270
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 2
+%% Original object ID: 10 0
+5 0 obj
+<<
+  /Length 6 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+6 0 obj
+52
+endobj
+
+xref
+0 7
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000420 00000 n 
+0000000601 00000 n 
+0000000708 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 7
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+727
+%%EOF

--- a/tests/exporter/test4_8_out.pdf
+++ b/tests/exporter/test4_8_out.pdf
@@ -1,0 +1,109 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    153
+    198
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /p2 6 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 25 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q 0.25 0 0 0.25 0 0 cm /p2 Do Q
+endstream
+endobj
+
+%QDF: ignore_newline
+5 0 obj
+31
+endobj
+
+%% Original object ID: 24 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+7 0 obj
+52
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000481 00000 n 
+0000000589 00000 n 
+0000000636 00000 n 
+0000000871 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 8
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+890
+%%EOF

--- a/tests/exporter/test5_8_out.pdf
+++ b/tests/exporter/test5_8_out.pdf
@@ -1,0 +1,71 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    61.2
+    316.8
+    489.6
+    554.4
+  ]
+  /Parent 2 0 R
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 10 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+5 0 obj
+52
+endobj
+
+xref
+0 6
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000432 00000 n 
+0000000539 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 6
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+558
+%%EOF

--- a/tests/exporter/test6_8_out.pdf
+++ b/tests/exporter/test6_8_out.pdf
@@ -1,0 +1,109 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 3
+  /Kids [
+    3 0 R
+    4 0 R
+    5 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 6 0 R
+  /MediaBox [
+    183.6
+    79.2
+    367.2
+    633.6
+  ]
+  /Parent 2 0 R
+  /Rotate 90
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 23 0
+4 0 obj
+<<
+  /Contents 6 0 R
+  /MediaBox [
+    122.4
+    237.6
+    550.8
+    475.2
+  ]
+  /Parent 2 0 R
+  /Rotate 180
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 24 0
+5 0 obj
+<<
+  /Contents 6 0 R
+  /MediaBox [
+    244.8
+    158.4
+    428.4
+    712.8
+  ]
+  /Parent 2 0 R
+  /Rotate 270
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 10 0
+6 0 obj
+<<
+  /Length 7 0 R
+>>
+stream
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+7 0 obj
+52
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000262 00000 n 
+0000000440 00000 n 
+0000000620 00000 n 
+0000000813 00000 n 
+0000000920 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 8
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+939
+%%EOF

--- a/tests/exporter/test7_8_out.pdf
+++ b/tests/exporter/test7_8_out.pdf
@@ -1,0 +1,142 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /J9u3ozUuw-IrRDh7dVLPcg 6 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 27 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+Q
+q
+1 0 0 1 0 0 cm
+/J9u3ozUuw-IrRDh7dVLPcg Do
+Q
+endstream
+endobj
+
+5 0 obj
+102
+endobj
+
+%% Original object ID: 23 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 8 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+7 0 obj
+101
+endobj
+
+%% Original object ID: 22 0
+8 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000501 00000 n 
+0000000658 00000 n 
+0000000706 00000 n 
+0000001091 00000 n 
+0000001139 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 9
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+1243
+%%EOF

--- a/tests/exporter/test8_8_out.pdf
+++ b/tests/exporter/test8_8_out.pdf
@@ -1,0 +1,140 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /DmszwNiMIhhnNiOyeDoOnw 6 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 25 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+q
+1 0 0 1 0 0 cm
+/DmszwNiMIhhnNiOyeDoOnw Do
+Q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+endstream
+endobj
+
+5 0 obj
+98
+endobj
+
+%% Original object ID: 23 0
+6 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    1
+    0
+    0
+    1
+    0
+    0
+  ]
+  /Resources <<
+    /Font <<
+      /F1 8 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 7 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+198.6 544.489 Td /F1 36 Tf (Underlay) Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+7 0 obj
+103
+endobj
+
+%% Original object ID: 22 0
+8 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 9
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000501 00000 n 
+0000000654 00000 n 
+0000000701 00000 n 
+0000001088 00000 n 
+0000001136 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 9
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+1240
+%%EOF

--- a/tests/exporter/test9_8_out.pdf
+++ b/tests/exporter/test9_8_out.pdf
@@ -1,0 +1,238 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 2
+  /Kids [
+    3 0 R
+    4 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 5 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /M96FhajihztljoPPq_2yuQ 7 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 23 0
+4 0 obj
+<<
+  /Contents 9 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /XObject <<
+      /kyl72QIgvVzaxF6WPUxYIA 11 0 R
+    >>
+  >>
+  /Rotate 0
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 29 0
+5 0 obj
+<<
+  /Length 6 0 R
+>>
+stream
+q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+Q
+q
+0.77273 0 0 0.77273 0 159.54545 cm
+/M96FhajihztljoPPq_2yuQ Do
+Q
+endstream
+endobj
+
+6 0 obj
+122
+endobj
+
+%% Original object ID: 25 0
+7 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    0
+    -1
+    1
+    0
+    0
+    612
+  ]
+  /Resources <<
+    /Font <<
+      /F1 13 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 8 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+8 0 obj
+101
+endobj
+
+%% Contents for page 2
+%% Original object ID: 34 0
+9 0 obj
+<<
+  /Length 10 0 R
+>>
+stream
+q
+1 0 0 rg 530 180 m 70 180 l 300 580 l h 530 180 m B
+Q
+q
+1 0 0 1 0 0 cm
+/kyl72QIgvVzaxF6WPUxYIA Do
+Q
+endstream
+endobj
+
+10 0 obj
+102
+endobj
+
+%% Original object ID: 30 0
+11 0 obj
+<<
+  /BBox [
+    0
+    0
+    612
+    792
+  ]
+  /Matrix [
+    -1
+    0
+    0
+    -1
+    612
+    792
+  ]
+  /Resources <<
+    /Font <<
+      /F1 13 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 12 0 R
+>>
+stream
+0.1 w
+q 0 0.028 595.275 841.861 re
+W* n
+q 0 0 0 rg
+BT
+234.1 558.289 Td /F1 36 Tf (Overlay)Tj
+ET
+Q
+Q 
+endstream
+endobj
+
+12 0 obj
+101
+endobj
+
+%% Original object ID: 22 0
+13 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+xref
+0 14
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000252 00000 n 
+0000000498 00000 n 
+0000000758 00000 n 
+0000000935 00000 n 
+0000000983 00000 n 
+0000001372 00000 n 
+0000001443 00000 n 
+0000001601 00000 n 
+0000001650 00000 n 
+0000002044 00000 n 
+0000002093 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 14
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+2198
+%%EOF


### PR DESCRIPTION
Experimental rewrite of exporter.export
- preserve internal links of main file (i.e. pdfqueue[0])
- preserve table of content/bookmarks of main file
- preserve form fields of main file

Definitely requires further work if this looks promising