### PR TITLE
Fix issues with very small & very large thumbnails

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -398,6 +398,7 @@ class PageAdder:
         self.app.model_unlock()
         if add_to_undomanager:
             GObject.idle_add(self.app.retitle)
+            self.app.zoom_set(self.app.zoom_level)
             self.app.silent_render()
         self.pages = []
         return True

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -633,19 +633,14 @@ class PdfArranger(Gtk.Application):
         page.zoom = self.zoom_scale
         if is_preview:
             page.preview = thumbnail
-        cell_width, _ = self.cellthmb.get_fixed_size()
-        if cell_width > self.sw.get_allocated_width():
-            # Let iconview do a "full refresh" by writing page to model.
-            self.model[path][0] = page
-        else:
-            # Let iconview refresh the thumbnail (only) by selecting it.
-            with GObject.signal_handler_block(self.iconview, self.id_selection_changed_event):
-                if self.iconview.path_is_selected(path):
-                    self.iconview.unselect_path(path)
-                    self.iconview.select_path(path)
-                else:
-                    self.iconview.select_path(path)
-                    self.iconview.unselect_path(path)
+        # Let iconview refresh the thumbnail (only) by selecting it
+        with GObject.signal_handler_block(self.iconview, self.id_selection_changed_event):
+            if self.iconview.path_is_selected(path):
+                self.iconview.unselect_path(path)
+                self.iconview.select_path(path)
+            else:
+                self.iconview.select_path(path)
+                self.iconview.unselect_path(path)
         self.__update_statusbar(path.get_indices()[0] + 1)
 
     def get_visible_range2(self):
@@ -1694,6 +1689,7 @@ class PdfArranger(Gtk.Application):
             row[0].zoom = self.zoom_scale
         if len(self.model) > 0:
             self.update_iconview_geometry()
+            self.model[0][0] = self.model[0][0]  # Let iconview refresh itself
             self.id_scroll_to_sel = GObject.timeout_add(400, self.scroll_to_selection)
             self.silent_render()
 

--- a/pdfarranger/undo.py
+++ b/pdfarranger/undo.py
@@ -79,6 +79,7 @@ class Manager(object):
             page.zoom = self.app.zoom_scale
             self.model.append([page, page.description()])
         self.app.model_unlock()
+        self.app.zoom_set(self.app.zoom_level)
         self.app.silent_render()
 
     def __refresh(self):


### PR DESCRIPTION
To reproduce the issues fixed:
* Open a large pdf
* Zoom in so thumbnail is wider than window
* While it still renders, try to scroll -> it is slow
* Remove the pdf
* Zoom out to smallest possible
* Open a less heavy pdf
* Select all + change scale factor to 1% (smallest possible)
* Zoom in slowly -> at some point thumbnails will be cropped at top and bottom. When cell width has grown wider than 50px the problem is gone.
* Zoom in to max
* Select all + change scale factor to 5000% (largest possible) -> "cairo.Error: invalid value (typically too big)"


Iconview also has issues when iw height goes over 2^23 pixels. Cells in beginning and in the end of iw will not be rendered then. 2^23 pixels will roughly be reached with a 3000 pages pdf when zoomed to max.
This issue is not fixed here.