### PR TITLE
Add tolerance to detect same page format

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1230,9 +1230,12 @@ class PdfArranger(Gtk.Application):
         elif selectoption == 'SAME_FORMAT':
             selection = self.iconview.get_selected_items()
             formats = set(model[row][0].size_in_points() for row in selection)
+            # Chop digits to detect same page format on rotated cropped pages
+            formats = [(round(w, 8), round(h, 8)) for (w, h) in formats]
             for row in model:
                 page = model[row.path][0]
-                if page.size_in_points() in formats:
+                w, h = page.size_in_points()
+                if (round(w, 8), round(h, 8)) in formats:
                     self.iconview.select_path(row.path)
         elif selectoption == 'INVERT':
             for row in model:


### PR DESCRIPTION
Accuracy can be lost in the computation of the page format when crops are flipped

- Load an A4 page
- Set the top crop to 6.7 and the bottom crop to 55.3
- Duplicate the page
- Rotate the second page by 180 degrees
- Select one of the two pages
- Select same page format

Only one page is selected although both pages have the same page format. Strange looking crops as above could be the result of the crop-white-borders features. This fix prunes some digits to relax the condition on what is considered the same page format.
