### PR TITLE
Set minimum pikepdf version to 1.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ lines.
 
 ## Install from source
 
-*PDF Arranger* requires [pikepdf](https://github.com/pikepdf/pikepdf) >= 1.7.0, but pikepdf >= 1.15.1 is highly recommended.
+*PDF Arranger* requires [pikepdf](https://github.com/pikepdf/pikepdf) >= 1.17.0.
 pip will automatically install the latest pikepdf if there is no pikepdf installed on the system.
 
 **On Debian based distributions**

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -15,10 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-import copy
 import pikepdf
-import traceback
-import sys
 import os
 import tempfile
 from . import metadata
@@ -149,18 +146,6 @@ def export(input_files, pages, file_out, mode, mdata):
         angle = row.angle
         angle0 = current_page.Rotate if '/Rotate' in current_page else 0
         new_page = pdf_output.copy_foreign(current_page)
-        # Workaround for pikepdf <= 1.10.1
-        # https://github.com/pikepdf/pikepdf/issues/80#issuecomment-590533474
-        try:
-            new_page = copy.copy(new_page)
-        except TypeError:
-            if _report_pikepdf_err:
-                _report_pikepdf_err = False
-                traceback.print_exc()
-                print("Current pikepdf version {}, required pikepdf version "
-                      "1.7.0 or greater. Continuing but PDF Arranger will not "
-                      "work properly.".format(pikepdf.__version__),
-                      file=sys.stderr)
         if angle != 0:
             new_page.Rotate = angle + angle0
         new_page.MediaBox = _mediabox(new_page, row.crop)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     entry_points={
         'console_scripts': ['pdfarranger=pdfarranger.pdfarranger:main']
     },
-    install_requires=['pikepdf>=1.7.0','python-dateutil>=2.4.0'],
+    install_requires=['pikepdf>=1.17.0','python-dateutil>=2.4.0'],
     extras_require={
         'image': ['img2pdf>=0.3.4'],
     },


### PR DESCRIPTION
* All major distro now have it
* Drop a workaround for https://github.com/pdfarranger/pdfarranger/issues/141 /
  https://github.com/pikepdf/pikepdf/issues/80
* Close #460