### PR TITLE
option to crop content only

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -58,7 +58,7 @@ _ = gettext.gettext
 
 
 class Page:
-    def __init__(self, nfile, npage, zoom, copyname, angle, scale, crop, size, basename):
+    def __init__(self, nfile, npage, zoom, copyname, angle, scale, crop, clip, size, basename):
         #: The ID (from 1 to n) of the PDF file owning the page
         self.nfile = nfile
         #: The ID (from 1 to n) of the page in its owner PDF document
@@ -68,6 +68,8 @@ class Page:
         self.copyname = copyname
         #: Left, right, top, bottom crop
         self.crop = list(crop)
+        #: If True only crop content, retain page size
+        self.clip = clip
         #: width and height
         self.size = list(size)
         self.angle = angle
@@ -125,7 +127,7 @@ class Page:
 
     def serialize(self):
         """Convert to string for copy/past operations."""
-        ts = [self.copyname, self.npage, self.basename, self.angle, self.scale] + list(self.crop)
+        ts = [self.copyname, self.npage, self.basename, self.angle, self.scale] + list(self.crop) + [self.clip]
         return "\n".join([str(v) for v in ts])
 
     def duplicate(self, incl_thumbnail=True):
@@ -319,8 +321,9 @@ class PageAdder:
         self.before = before
         self.treerowref = treerowref
 
-    def addpages(self, filename, page=-1, basename=None, angle=0, scale=1.0, crop=None):
+    def addpages(self, filename, page=-1, basename=None, angle=0, scale=1.0, crop=None, clip=None):
         crop = [0] * 4 if crop is None else crop
+        clip = False if clip is None else clip
         pdfdoc = None
         nfile = None
         # Check if added page or file already exist in pdfqueue
@@ -369,6 +372,7 @@ class PageAdder:
                     angle,
                     scale,
                     crop,
+                    clip,
                     page.get_size(),
                     pdfdoc.basename,
                 )

--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -166,9 +166,11 @@ class _CropWidget(Gtk.Frame):
         self.spin_list = []
         units = 2 * [_('% of width')] + 2 * [_('% of height')]
         crop = [0.0, 0.0, 0.0, 0.0]
+        clip = False
         if selection:
             pos = model.get_iter(selection[0])
             crop = list(model.get_value(pos, 0).crop)
+            clip = model.get_value(pos, 0).clip
 
         for row, side in enumerate(_CropWidget.sides):
             label = Gtk.Label(label=_CropWidget.side_names[side])
@@ -192,6 +194,11 @@ class _CropWidget(Gtk.Frame):
             label = Gtk.Label(label=units.pop(0))
             label.set_alignment(0.0, 0.5)
             grid.attach(label, 2, row + 1, 1, 1)
+      
+        self.clipcheck = Gtk.CheckButton()
+        self.clipcheck.set_label("Crop content only, retain page margins")
+        self.clipcheck.set_active(clip)
+        grid.attach(self.clipcheck, 0, 5, 3, 1)
 
     @staticmethod
     def __set_crop_value(spinbutton, self, side):
@@ -202,6 +209,8 @@ class _CropWidget(Gtk.Frame):
     def get_crop(self):
         return [spin.get_value() / 100.0 for spin in self.spin_list]
 
+    def get_clip(self):
+        return self.clipcheck.get_active()
 
 class Dialog(Gtk.Dialog):
     """ A dialog box to define margins for page cropping and page size or scale factor """
@@ -244,9 +253,11 @@ class Dialog(Gtk.Dialog):
         """ Open the dialog and return the crop value """
         result = self.run()
         crop = None
+        clip = None
         val = None
         if result == Gtk.ResponseType.OK:
             crop = [self.crop_widget.get_crop()] * len(self.selection)
+            clip = self.crop_widget.get_clip() * len(self.selection)
             val = self.scale_stack.selected_child.get_value()
             if self.scale_stack.selected_name == "Width":
                 val = val, 0
@@ -254,7 +265,7 @@ class Dialog(Gtk.Dialog):
                 val = 0, val
             # else val is a relative scale so we return it as is
         self.destroy()
-        return crop, val
+        return crop, clip, val
 
 
 def white_borders(model, selection, pdfqueue):


### PR DESCRIPTION
Option to clip the content instead of cropping the entire page.
The poppler preview displays the regular cropping method, but saving as pdf creates differently cropped files.