### PR TITLE
Fix alpha channel removal for LA images

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -280,7 +280,7 @@ class PDFDoc:
                 os.close(fd)
                 with open(self.copyname, "wb") as f:
                     img = img2pdf.Image.open(filename)
-                    if (image.mode == "LA") or (img.mode != "RGBA" and "transparency" in img.info):
+                    if (img.mode == "LA") or (img.mode != "RGBA" and "transparency" in img.info):
                         # TODO: Find a way to keep image in P or L format and remove transparency.
                         # This will work but converting from 1, L, P to RGB is not optimal.
                         img = img.convert("RGBA")

--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -280,7 +280,7 @@ class PDFDoc:
                 os.close(fd)
                 with open(self.copyname, "wb") as f:
                     img = img2pdf.Image.open(filename)
-                    if img.mode != "RGBA" and "transparency" in img.info:
+                    if (image.mode == "LA") or (img.mode != "RGBA" and "transparency" in img.info):
                         # TODO: Find a way to keep image in P or L format and remove transparency.
                         # This will work but converting from 1, L, P to RGB is not optimal.
                         img = img.convert("RGBA")


### PR DESCRIPTION
LA images were wrongly not converted to RGBA since they do not contain the "transparency" information (for whatever reason). Nevertheless, they have an alpha channel that needs to be removed prior to forwarding the file to img2pdf.
This patch fixes the problem by explicitly checking for LA mode.