### PR TITLE
README.md: FreeBSD: alternative approach to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ sudo dnf install poppler-glib python3-distutils-extra python3-pip python3-gobjec
 
 **On FreeBSD**
 
+`cd /usr/ports/print/pdfarranger/ && sudo make install clean`
+
+* see https://www.freshports.org/print/pdfarranger/#add
+* no need for subsequent use of `pip3`
+
+– or: 
+
 ```
 sudo pkg install devel/gettext devel/py-gobject3 devel/py-pip devel/py-python-distutils-extra graphics/poppler-glib textproc/intltool textproc/py-pikepdf x11-toolkits/gtk30
 ```


### PR DESCRIPTION
Preparing for intended addition of PDF Arranger to the ports collection for FreeBSD. 

If all goes well: 

1. I'll remove PDF Arranger from <https://wiki.freebsd.org/WantedPorts>
2. await appearance of packages under <https://www.freshports.org/print/pdfarranger/#packages>
3. we can request a listing at <https://github.com/pdfarranger/pdfarranger/wiki/Binary-packages>.

### Background

* https://github.com/pdfarranger/pdfarranger/issues/381
* the port to OpenBSD, https://github.com/openbsd/ports/tree/master/print/pdfarranger
* https://forums.FreeBSD.org/threads/80375/post-514535

> … submit the port tonight. 