### PR TITLE
Fix OK button in metadata dialog

### DIFF
--- a/pdfarranger/metadata.py
+++ b/pdfarranger/metadata.py
@@ -182,7 +182,8 @@ def edit(metadata, pdffiles, parent):
                         flags=Gtk.DialogFlags.MODAL,
                         buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                                  Gtk.STOCK_OK, Gtk.ResponseType.OK))
-    dialog.set_default_response(Gtk.ResponseType.OK)
+    ok_button = dialog.get_widget_for_response(response_id = Gtk.ResponseType.OK)
+    ok_button.grab_focus()
     # Property, Value, XMP name (hidden)
     liststore = Gtk.ListStore(str, str, str)
     mergedmetadata = merge(metadata, pdffiles)


### PR DESCRIPTION
`dialog.set_default_response(Gtk.ResponseType.OK)` does not have an effect because TreeView gets the focus. Manually set the focus so that pressing enter defaults to the OK button.