### PR TITLE
Move export pdf to separate thread

### DIFF
--- a/pdfarranger/metadata.py
+++ b/pdfarranger/metadata.py
@@ -23,6 +23,8 @@ import json
 import traceback
 from datetime import datetime
 from dateutil import parser
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 _ = gettext.gettext
 
@@ -78,8 +80,8 @@ def load_from_docinfo(meta, doc):
 def merge(metadata, input_files):
     """ Merge current global metadata and each imported files meta data """
     r = metadata.copy()
-    for p in input_files:
-        doc = pikepdf.open(p.copyname, password=p.password)
+    for copyname, password in input_files:
+        doc = pikepdf.open(copyname, password=password)
         with doc.open_metadata() as meta:
             load_from_docinfo(meta, doc)
             for k, v in meta.items():

--- a/tests/test.py
+++ b/tests/test.py
@@ -365,6 +365,7 @@ class TestBatch1(PdfArrangerTest):
         dialog = self._app().child(roleName="alert")
         dialog.child(name="Cancel").click()
         self._app().keyCombo("<ctrl>s")
+        time.sleep(5)  # Let the save finish before quit
         self._app().keyCombo("<ctrl>q")
         # check that process actually exit
         self._process().wait(timeout=22)


### PR DESCRIPTION
Before I do more work on this I could have your opinion about it. :-)

When saving a larger pdf the app will freeze until file is saved. The save dialog can stay open for a long time when you press save. App can not be quited while saving. No "Saving" info is provided to user while saving. So here I try to do something about these issues. We can wait until 1.9.0 if you think it is to much for 1.8.0.