### PR TITLE
Readme: Hide eol distributions in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It’s a humble attempt to make the project a bit more active.
 
 ### Linux and BSD packages
 
-[![Linux packages](https://repology.org/badge/vertical-allrepos/pdfarranger.svg?columns=4)](https://repology.org/project/pdfarranger/versions)
+[![Linux packages](https://repology.org/badge/vertical-allrepos/pdfarranger.svg?columns=4&exclude_unsupported=1)](https://repology.org/project/pdfarranger/versions)
 
 ## Customization of keyboard shortcuts
 


### PR DESCRIPTION
At the moment this hides only 4 outdated Fedora versions and Ubuntu 20.10 (also eol), but it will become more in the future.
Repology added this feature just recently: https://github.com/repology/repology-webapp/issues/117