### PR TITLE
Fix zoom scale issues

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1802,22 +1802,22 @@ class PdfArranger(Gtk.Application):
     def zoom_set(self, level):
         """Sets the zoom level"""
         level = min(max(level, -10), 40)
-        zoom_level_old = self.zoom_level
-        self.zoom_level = level
-        self.zoom_scale = 0.2 * (1.1 ** level)
+        zoom_scale = 0.2 * (1.1 ** level)
         # Limit max zoom level so that thumbnail is max 23Mb
         if len(self.model) > 0:
             max_limit = 6000000  # 6000000 pixels * 4 byte/pixel -> 23Mb
             max_page_size = max(p.size[0] * p.size[1] * p.scale ** 2 for p, _ in self.model)
-            max_page_size_zoomed = max_page_size * self.zoom_scale ** 2
+            max_page_size_zoomed = max_page_size * zoom_scale ** 2
             if max_page_size_zoomed > max_limit:
                 max_zoom_scale = (max_limit / max_page_size) ** .5
-                self.zoom_level = -10
-                while max_zoom_scale > 0.2 * (1.1 ** (self.zoom_level + 1)):
-                    self.zoom_level += 1
-                self.zoom_scale = 0.2 * (1.1 ** self.zoom_level)
-        if self.zoom_level == zoom_level_old:
+                level = -10
+                while max_zoom_scale > 0.2 * (1.1 ** (level + 1)):
+                    level += 1
+                zoom_scale = 0.2 * (1.1 ** level)
+        if self.zoom_level == level:
             return
+        self.zoom_level = level
+        self.zoom_scale = zoom_scale
         if self.id_scroll_to_sel:
             GObject.source_remove(self.id_scroll_to_sel)
         self.zoom_full_page = False

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1856,9 +1856,7 @@ class PdfArranger(Gtk.Application):
         margins = 12  # leave 6 pixel at top and 6 pixel at bottom
         zoom_scaleX_new = (sw_width - cell_extraX - margins) / page_width
         zoom_scaleY_new = (sw_height - cell_extraY - margins) / page_height
-        self.zoom_scale = min(zoom_scaleY_new, zoom_scaleX_new)
-        if self.zoom_scale < 0.2 * (1.1 ** -10):
-            return
+        self.zoom_scale = max(min(zoom_scaleY_new, zoom_scaleX_new), 0.2 * (1.1 ** -10))
         self.quit_rendering()  # For performance reasons
         for page, _ in self.model:
             page.zoom = self.zoom_scale


### PR DESCRIPTION
Steps to reproduce the issue:
* Open a PDF and zoom to full page
* Select all + Cut
* Paste
-> The pages will not receive a thumbnail. Thumbnail is rendered but update_thumbnail does not accept the page.