### PR TITLE
Ensure iconview is updated when zooming to full page

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1860,6 +1860,7 @@ class PdfArranger(Gtk.Application):
         self.quit_rendering()  # For performance reasons
         for page, _ in self.model:
             page.zoom = self.zoom_scale
+        self.model[0][0] = self.model[0][0]
 
         # Set zoom level to nearest possible so zoom in/out works right
         self.zoom_level = -10


### PR DESCRIPTION
The commit is needed for this case:
* Open a pdf
* Adjust the view so that when zooming to full page the thumbnail size will be limited by window width (and not height)
* Zoom in so horizontal scrollbar becomes visible
* Select a page and Zoom to full page
-> it will not zoom properly
