### PR TITLE
Fix a button location issue in Insert Blank Page dialog

### DIFF
--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -350,6 +350,8 @@ class BlankPageDialog(Gtk.Dialog):
                 Gtk.ResponseType.OK,
             ),
         )
+        self.set_default_response(Gtk.ResponseType.OK)
+        self.set_resizable(False)
         self.width_widget = _ScalingWidget(_("Width"), size[0])
         self.height_widget = _ScalingWidget(_("Height"), size[1])
         self.vbox.pack_start(self.width_widget, True, True, 6)
@@ -357,8 +359,6 @@ class BlankPageDialog(Gtk.Dialog):
         self.width_widget.props.spacing = 6
         self.height_widget.props.spacing = 6
         self.show_all()
-        self.set_resizable(False)
-        self.set_default_response(Gtk.ResponseType.OK)
 
     def run_get(self):
         result = self.run()


### PR DESCRIPTION
In KDE minimize and close buttons are too far to the left
![insert blank page](https://user-images.githubusercontent.com/60842129/142772764-ed213627-4587-4e15-b306-e40d666453ef.png)
Before the commit to left, after to right
