### PR TITLE
Fix a case when statusbar is not updated

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1805,6 +1805,7 @@ class PdfArranger(Gtk.Application):
                 filename = get_file_path_from_uri(uri)
                 pageadder.addpages(filename)
             pageadder.commit(select_added=False, add_to_undomanager=True)
+            self.iv_selection_changed_event()
 
     def sw_button_press_event(self, _scrolledwindow, event):
         """Unselects all items in iconview on mouse click in scrolledwindow"""


### PR DESCRIPTION
It is actually possible to crash the app because of this bug:
* Select two pages
* Drag in a file between
* Try the "reverse order" action
-> segmentation fault -> app closes