### PR TITLE
Instruct developers to install using pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 venv/
+pdfarranger.egg-info/
+build/

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In addition, *PDF Arranger* supports image file import if [img2pdf](https://gitl
 ```
 git clone https://github.com/pdfarranger/pdfarranger.git
 cd pdfarranger
-./setup.py build
+pip3 install --user .
 python3 -m pdfarranger
 ```
 


### PR DESCRIPTION
pip allows you to uninstall while ./setup.py doesn't.

As suggested in https://github.com/pdfarranger/pdfarranger/issues/604#issuecomment-1003955304 - I've been using pip install for a long time and didn't have issues. 