### PR TITLE
ui: port to libhandy

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -6,8 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # PikePDF 4.2.0
-    container: jeromerobert/pdfarranger-docker-ci:1.4
+    # PikePDF 4.4.1
+    container: jeromerobert/pdfarranger-docker-ci:1.4.1
     env:
       PDFARRANGER_COVERAGE: 1
     steps:
@@ -27,7 +27,7 @@ jobs:
   build-old-pikepdf:
     runs-on: ubuntu-latest
     # PikePDF 1.19
-    container: jeromerobert/pdfarranger-docker-ci:1.3.1
+    container: jeromerobert/pdfarranger-docker-ci:1.3.2
     steps:
     - uses: actions/checkout@v2
     - name: Install
@@ -37,7 +37,7 @@ jobs:
   build-win32:
     runs-on: ubuntu-latest
     container:
-      image: jeromerobert/wine-mingw64:1.7.0
+      image: jeromerobert/wine-mingw64:1.7.1
       options: --user root
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip will automatically install the latest pikepdf if there is no pikepdf install
 **On Debian based distributions**
 
 ```
-sudo apt-get install python3-pip python3-distutils-extra python3-wheel python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-poppler-0.18 python3-setuptools
+sudo apt-get install python3-pip python3-distutils-extra python3-wheel python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-poppler-0.18 gir1.2-handy-1 python3-setuptools
 ```
 
 **On Arch Linux**

--- a/data/pdfarranger.ui
+++ b/data/pdfarranger.ui
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
 <!--
 Copyright (C) 2020 Jerome Robert
 
@@ -19,13 +18,15 @@ You should have received a copy of the GNU General Public License
 along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
-  <object class="GtkApplicationWindow" id="main_window">
+  <object class="HdyApplicationWindow" id="main_window">
     <property name="show_menubar">False</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="header_bar">
+    <child>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="spacing">4</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="HdyHeaderBar" id="header_bar">
+        <property name="visible">True</property>
         <property name="show_close_button">True</property>
         <child>
           <object class="GtkBox">
@@ -260,6 +261,7 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
       <object class="GtkBox" id="main_box">
         <property name="visible">True</property>
         <property name="orientation">vertical</property>
+            <property name="expand">True</property>
         <child>
           <object class="GtkScrolledWindow" id="scrolledwindow">
             <property name="visible">True</property>
@@ -331,6 +333,8 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
           </packing>
         </child>
       </object>
+    </child>
+  </object>
     </child>
   </object>
 </interface>

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -87,7 +87,9 @@ import gi
 # check that we don't need GObject.threads_init()
 gi.check_version('3.10.2')
 gi.require_version('Gtk', '3.0')
+gi.require_version('Handy', '1')
 from gi.repository import Gtk
+from gi.repository import Handy
 
 if Gtk.check_version(3, 12, 0):
     raise Exception('You do not have the required version of GTK+ installed. ' +
@@ -135,7 +137,7 @@ def _install_workaround_bug29():
                 action.connect("activate", d[1], None)
                 self.add_action(action)
 
-        Gtk.ApplicationWindow.add_action_entries = func
+        Handy.ApplicationWindow.add_action_entries = func
 
 
 _install_workaround_bug29()
@@ -295,7 +297,7 @@ class PdfArranger(Gtk.Application):
         main_menu.set_menu_model(b.get_object("main_menu"))
 
     def __create_actions(self):
-        # Both Gtk.ApplicationWindow and Gtk.Application are Gio.ActionMap. Some action are window
+        # Both Handy.ApplicationWindow and Gtk.Application are Gio.ActionMap. Some action are window
         # related some other are application related. As pdfarrager is a single window app does not
         # matter that much.
         self.actions = [
@@ -433,12 +435,13 @@ class PdfArranger(Gtk.Application):
         if not os.path.exists(iconsdir):
             iconsdir = os.path.join(sharedir, 'data', 'icons')
         Gtk.IconTheme.get_default().append_search_path(iconsdir)
-        Gtk.Window.set_default_icon_name(ICON_ID)
+        Handy.Window.set_default_icon_name(ICON_ID)
+        Handy.init()
         self.uiXML = self.__build_from_file(DOMAIN + '.ui')
         # Create the main window, and attach delete_event signal to terminating
         # the application
         self.window = self.uiXML.get_object('main_window')
-        self.window.set_title(APPNAME)
+        self.uiXML.get_object('header_bar').set_title(APPNAME)
         self.window.set_border_width(0)
         self.window.set_application(self)
         if self.config.maximized():
@@ -752,7 +755,7 @@ class PdfArranger(Gtk.Application):
             title += ' [' + ', '.join(sorted(all_files)) + ']'
 
         title += ' – ' + APPNAME
-        self.window.set_title(title)
+        self.uiXML.get_object('header_bar').set_title(title)
         return False
 
     def update_thumbnail(self, _obj, ref, thumbnail, resample, scale, is_preview):

--- a/setup_win32.py
+++ b/setup_win32.py
@@ -91,6 +91,7 @@ required_dlls = [
     'poppler-glib-8',
     'xml2-2',
     'rsvg-2-2',
+    'handy-1-0',
 ]
 
 for dll in required_dlls:
@@ -113,7 +114,8 @@ required_gi_namespaces = [
     "GModule-2.0",
     "Atk-1.0",
     "Poppler-0.18",
-    "HarfBuzz-0.0"
+    "HarfBuzz-0.0",
+    "Handy-1",
 ]
 
 for ns in required_gi_namespaces:


### PR DESCRIPTION
GtkApplicationWindow is now a HdyApplicationWindow and GtkHeaderBar is now a HdyHeaderBar, a GtkBox is needed now between HdyApplicationWindow and the rest of the UI elements.

This change enables bottom rounded corners (at least on Linux) and will also allow PDF Arranger to follow system theme (Linux) with libhandy 1.5 ([docs](https://gnome.pages.gitlab.gnome.org/libhandy/doc/main/HdyStyleManager.html)). That's not implemented here as libhandy 1.5 is not out yet.

I haven't noticed any regressions, although it was only tested on Linux.