### PR TITLE
Remove trademark sign from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It’s a humble attempt to make the project a bit more active.
 
 ## Downloads
 
-| [Microsoft® Windows®](https://github.com/pdfarranger/pdfarranger/releases) | <a href='https://flathub.org/apps/details/com.github.jeromerobert.pdfarranger'><img width='120' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.svg'/></a> | [More…](https://github.com/pdfarranger/pdfarranger/wiki/Binary-packages) |
+| [PDF Arranger for Windows](https://github.com/pdfarranger/pdfarranger/releases) | <a href='https://flathub.org/apps/details/com.github.jeromerobert.pdfarranger'><img width='120' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.svg'/></a> | [More…](https://github.com/pdfarranger/pdfarranger/wiki/Binary-packages) |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 
 ### Linux and BSD packages


### PR DESCRIPTION
Let me quote the [Fedora Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_trademarks_in_summary_or_description) on that topic:
> Never use (TM) or (R) (or the Unicode equivalents, ™/®). It is incredibly complicated to use these properly, so it is actually safer for us to not use them at all.

IANAL but the same should be true for us.

If this PR is accepted, someone should also:
- [x] Update the [Wiki page](https://github.com/pdfarranger/pdfarranger/wiki/Binary-packages)