### PR TITLE
Fix seg fault if clicking in iconview too early

### DIFF
--- a/pdfarranger/iconview.py
+++ b/pdfarranger/iconview.py
@@ -384,6 +384,9 @@ class IconviewDragSelect:
              Location is 2.5 when pointer is between item 2 and 3.
         """
         last = self.iconview.get_cell_rect(self.model[-1].path)[1]
+        if last.width < 50:
+            # Avoid seg fault if calling get_path_at_pos before iconview is ready
+            return None
         last_x, last_y = self.iconview.convert_widget_to_bin_window_coords(last.x, last.y)
         x_step = last.width - 2 * self.iconview.get_item_padding() - 1
         y_step = self.iconview.get_row_spacing() + 2 * self.iconview.get_item_padding() + 1


### PR DESCRIPTION
To reproduce: Open a large file and immediately click in iconview
Issue since: 4f4148d

This is a alternative fix:
```
--- a/pdfarranger/iconview.py
+++ b/pdfarranger/iconview.py
@@ -396,7 +396,7 @@ class IconviewDragSelect:
                       ('Above', x, y - y_step),
                       ('Above', x + x_step, y - y_step),
                       ('Above', x - x_step, y - y_step),
-                      ('Zero', 0, 0)]
+                      ('Zero', 3, 3)]
```
But I think the commit is better
