### PR TITLE
Show save warnings in a more informative dialog

### DIFF
--- a/pdfarranger/config.py
+++ b/pdfarranger/config.py
@@ -145,6 +145,12 @@ class Config(object):
     def set_content_loss_warning(self, enabled):
         self.data.set('preferences', 'content-loss-warning', str(enabled))
 
+    def show_save_warnings(self):
+        return self.data.getboolean('preferences', 'show-save-warnings', fallback=True)
+
+    def set_show_save_warnings(self, enabled):
+        self.data.set('preferences', 'show-save-warnings', str(enabled))
+
     def save(self):
         conffile = Config._config_file(self.domain)
         os.makedirs(os.path.dirname(conffile), exist_ok=True)


### PR DESCRIPTION
Messages like `The metadata field /Trapped with value 'pikepdf.Name("/False")' has no XMP equivalent, so it was discarded` seems to be common. I think users will be confused when this pops up. But I am not sure what the text should be here. Anyone got ideas? Should there be the option to not show warnings? At least I have never seen any issues with the PDF when there has been warnings.

The message is also put in a scrolled window here so the dialog cant grow large.

Current:
![image](https://user-images.githubusercontent.com/60842129/157062455-d50664c4-f17f-46c2-b6cd-55deef779775.png)


The PR:
![image](https://user-images.githubusercontent.com/60842129/157057936-304b9af5-a3a1-48ec-a5f1-c79979d4c94a.png)
![image](https://user-images.githubusercontent.com/60842129/157061825-03046b6b-296c-4587-9520-c3de57fd4ebb.png)


Idea 2:
![image](https://user-images.githubusercontent.com/60842129/157059281-af08913f-7067-4831-bd70-c952aadffaa8.png)
