### PR TITLE
Add libhandy to Arch Linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo apt-get install python3-pip python3-distutils-extra python3-wheel python3-g
 **On Arch Linux**
 
 ```
-sudo pacman -S poppler-glib python-distutils-extra python-pip python-gobject gtk3 python-cairo
+sudo pacman -S poppler-glib python-distutils-extra python-pip python-gobject gtk3 python-cairo libhandy
 ```
 
 **On Fedora**


### PR DESCRIPTION
Without libhandy (no, gtk3 doesn't provide that), pdfarranger complains:

```plaintext
Traceback (most recent call last):
  File "/home/fkfd/.local/bin/pdfarranger", line 33, in <module>
    sys.exit(load_entry_point('pdfarranger==1.9.0.dev1', 'console_scripts', 'pdfarranger')())
  File "/home/fkfd/.local/bin/pdfarranger", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/fkfd/.local/lib/python3.10/site-packages/pdfarranger/pdfarranger.py", line 90, in <module>
    gi.require_version('Handy', '1')
  File "/usr/lib/python3.10/site-packages/gi/__init__.py", line 126, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Handy not available
```