### PR TITLE
Hide cursor and fix shift-click-selecting issue

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1830,6 +1830,7 @@ class PdfArranger(Gtk.Application):
             selection = iconview.get_selected_items()
             if self.click_path and self.click_path in selection:
                 self.pressed_button = event
+                self.iconview.set_cursor(self.click_path, None, False)
                 return 1  # prevent propagation i.e. (de-)selection
 
         # Display right click menu


### PR DESCRIPTION
The last commit had one issue.. it will not hide the cursor if it happens to be visible. I haven't found a command that would hide the cursor, but in this hacky way it can be done anyway.

If shift is pressed it will not hide cursor but in this case it should not be a issue as the cursor will still be inside the selection.