### PR TITLE
Remove name of blank page from titlebar

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -766,6 +766,7 @@ class PdfArranger(Gtk.Application):
             title += '*'
 
         all_files = set(os.path.splitext(doc.basename)[0] for doc in self.pdfqueue)
+        all_files.discard('')
         if len(all_files) > 0:
             title += ' [' + ', '.join(sorted(all_files)) + ']'
 


### PR DESCRIPTION
Currently it will add this extra comma:
![image](https://user-images.githubusercontent.com/60842129/166097455-fa8daa2e-5286-4123-b623-38f1d95965bb.png)
