### PR TITLE
Fix a spacing issue in page format dialog

### DIFF
--- a/pdfarranger/croputils.py
+++ b/pdfarranger/croputils.py
@@ -128,8 +128,9 @@ class _RelativeScalingWidget(Gtk.Box):
 class _ScalingWidget(Gtk.Box):
     """ A form to specify the page width or height """
 
-    def __init__(self, label, default):
+    def __init__(self, label, default, margin=10):
         super().__init__()
+        self.props.spacing = margin
         self.add(Gtk.Label(label=label))
         self.entry = _LinkedSpinButton(25.4, 5080, 1, 10)
         self.entry.set_activates_default(True)


### PR DESCRIPTION
The missing space can be seen here:
![space2](https://user-images.githubusercontent.com/60842129/188664745-765fee66-cb87-4046-81c4-f77dde28d44d.jpg)
