### PR TITLE
manpage: fix NAME to be the actual executable name

### DIFF
--- a/doc/pdfarranger.1
+++ b/doc/pdfarranger.1
@@ -1,6 +1,6 @@
 .TH PDFARRANGER 1 "May 2019" "version 1.2" "User Manuals"
 .SH "NAME"
-PDF Arranger \- Application for PDF Merging, Rearranging, Splitting, and Cropping
+pdfarranger \- Application for PDF Merging, Rearranging, Splitting, and Cropping
 .SH "SYNOPSIS"
 .B pdfarranger [file1] [file2] ...
 .SH "DESCRIPTION"


### PR DESCRIPTION
lexgrog, which is used by mandb, ignores names with spaces (see lexgrog.1).