### PR TITLE
Fix a typo in Turkish translation

### DIFF
--- a/po/tr.po
+++ b/po/tr.po
@@ -2,16 +2,16 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the pdfarranger package.
 # Murathan BOSTANCI <murathan.bostanci@profelis.com.tr>, 2018
-# Oğuz Ersen <oguzersen@protonmail.com>, 2021, 2022.
+# Oğuz Ersen <oguz@ersen.moe>, 2021, 2022.
 # Emin Tufan Çetin <etcetin@gmail.com>, 2020, 2021, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: pdfarranger master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-30 18:26+0200\n"
+"POT-Creation-Date: 2022-11-03 21:53+0300\n"
 "PO-Revision-Date: 2022-08-08 17:51+0300\n"
-"Last-Translator: Emin Tufan Çetin <etcetin@gmail.com>\n"
+"Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
@@ -41,7 +41,7 @@ msgstr "“{}” belgesi kilitli ve açılmadan önce parola gerekiyor."
 msgid "Password"
 msgstr "Parola"
 
-#: pdfarranger/core.py:289 pdfarranger/pdfarranger.py:1433
+#: pdfarranger/core.py:289 pdfarranger/pdfarranger.py:1431
 msgid "Unknown file format"
 msgstr "Bilinmeyen dosya biçimi"
 
@@ -57,7 +57,7 @@ msgstr "Resim dosyası, img2pdf tarafından desteklenmiyor"
 msgid "Clipboard image"
 msgstr "Pano resmi"
 
-#: pdfarranger/core.py:316 pdfarranger/pdfarranger.py:1443
+#: pdfarranger/core.py:316 pdfarranger/pdfarranger.py:1441
 msgid "File is neither pdf nor image"
 msgstr "Dosya ne pdf ne de resimdir"
 
@@ -69,89 +69,89 @@ msgstr "Ölçek çarpanı"
 msgid "%"
 msgstr "%"
 
-#: pdfarranger/croputils.py:137
+#: pdfarranger/croputils.py:138
 msgid "mm"
 msgstr "mm"
 
-#: pdfarranger/croputils.py:147
+#: pdfarranger/croputils.py:148
 msgid "Left"
 msgstr "Sol"
 
-#: pdfarranger/croputils.py:147
+#: pdfarranger/croputils.py:148
 msgid "Right"
 msgstr "Sağ"
 
-#: pdfarranger/croputils.py:147
+#: pdfarranger/croputils.py:148
 msgid "Top"
 msgstr "Üst"
 
-#: pdfarranger/croputils.py:147
+#: pdfarranger/croputils.py:148
 msgid "Bottom"
 msgstr "Alt"
 
-#: pdfarranger/croputils.py:151
+#: pdfarranger/croputils.py:152
 msgid "Crop Margins"
 msgstr "Kenarları Kırp"
 
-#: pdfarranger/croputils.py:159
+#: pdfarranger/croputils.py:160
 msgid ""
 "Cropping does not remove any content from the PDF file, it only hides it."
 msgstr ""
 "Kırparak PDF dosyasından herhangi bir veri kaldırılmaz, yalnızca gizlenir."
 
-#: pdfarranger/croputils.py:168
+#: pdfarranger/croputils.py:169
 #, python-format
 msgid "% of width"
 msgstr "% olarak genişlik"
 
-#: pdfarranger/croputils.py:168
+#: pdfarranger/croputils.py:169
 #, python-format
 msgid "% of height"
-msgstr "% olarak yükselik"
+msgstr "% olarak yükseklik"
 
-#: pdfarranger/croputils.py:215
+#: pdfarranger/croputils.py:216
 msgid "Page format"
 msgstr "Sayfa biçimi"
 
-#: pdfarranger/croputils.py:230 pdfarranger/croputils.py:234
-#: pdfarranger/croputils.py:333
+#: pdfarranger/croputils.py:231 pdfarranger/croputils.py:235
+#: pdfarranger/croputils.py:334
 msgid "Width"
 msgstr "Genişlik"
 
-#: pdfarranger/croputils.py:231 pdfarranger/croputils.py:235
-#: pdfarranger/croputils.py:334
+#: pdfarranger/croputils.py:232 pdfarranger/croputils.py:236
+#: pdfarranger/croputils.py:335
 msgid "Height"
 msgstr "Yükseklik"
 
-#: pdfarranger/croputils.py:233
+#: pdfarranger/croputils.py:234
 msgid "Relative"
 msgstr "Göreceli"
 
-#: pdfarranger/croputils.py:236
+#: pdfarranger/croputils.py:237
 msgid "Page Size"
 msgstr "Sayfa Boyutu"
 
-#: pdfarranger/croputils.py:321
+#: pdfarranger/croputils.py:322
 msgid "Insert Blank Page"
 msgstr "Boş Sayfa Ekle"
 
-#: pdfarranger/exporter.py:130
+#: pdfarranger/exporter.py:158
 msgid "Warning"
 msgstr "Uyarı"
 
-#: pdfarranger/exporter.py:135
+#: pdfarranger/exporter.py:163
 msgid "Forms and outlines are lost on saving."
 msgstr "Kaydedilirken formlar ve konturlar yitirilecek."
 
-#: pdfarranger/exporter.py:137
+#: pdfarranger/exporter.py:165
 msgid "Do not show this dialog again."
 msgstr "Bu pencereyi yeniden gösterme."
 
-#: pdfarranger/exporter.py:342
+#: pdfarranger/exporter.py:382
 msgid "Printing…"
 msgstr "Yazdırılıyor…"
 
-#: pdfarranger/exporter.py:354
+#: pdfarranger/exporter.py:394
 msgid "Rendering Preview…"
 msgstr "Ön İzleme Oluşturuluyor…"
 
@@ -235,134 +235,140 @@ msgstr "Desteklenen tüm dosyalar"
 msgid "PDF files"
 msgstr "PDF dosyaları"
 
-#: pdfarranger/pdfarranger.py:467
+#: pdfarranger/pdfarranger.py:468
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: pdfarranger/pdfarranger.py:472
+#: pdfarranger/pdfarranger.py:473
 msgid "Supported image files"
 msgstr "Desteklenen resim dosyaları"
 
-#: pdfarranger/pdfarranger.py:691
+#: pdfarranger/pdfarranger.py:693
 msgid "Rendering…"
 msgstr "Oluşturuluyor…"
 
-#: pdfarranger/pdfarranger.py:769
+#: pdfarranger/pdfarranger.py:771
 msgid "untitled"
 msgstr "başlıksız"
 
-#: pdfarranger/pdfarranger.py:916 pdfarranger/pdfarranger.py:925
+#: pdfarranger/pdfarranger.py:918 pdfarranger/pdfarranger.py:927
+#: pdfarranger/pdfarranger.py:1027 pdfarranger/pdfarranger.py:1052
 msgid "_Cancel"
 msgstr "_İptal"
 
-#: pdfarranger/pdfarranger.py:924
+#: pdfarranger/pdfarranger.py:926
 msgid "Your changes will be lost if you don’t save them."
 msgstr "Kaydetmezseniz değişiklikleriniz yitecektir."
 
-#: pdfarranger/pdfarranger.py:925
+#: pdfarranger/pdfarranger.py:927
 msgid "Do_n’t Save"
 msgstr "Kaydet_me"
 
-#: pdfarranger/pdfarranger.py:925 data/menu.ui.h:4
+#: pdfarranger/pdfarranger.py:927 pdfarranger/pdfarranger.py:1026
+#: data/menu.ui.h:4
 msgid "_Save"
 msgstr "_Kaydet"
 
-#: pdfarranger/pdfarranger.py:934
+#: pdfarranger/pdfarranger.py:936
 msgid "Discard changes and close?"
 msgstr "Değişiklikler atılsın ve kapatılsın mı?"
 
-#: pdfarranger/pdfarranger.py:935 data/menu.ui.h:45
+#: pdfarranger/pdfarranger.py:937 data/menu.ui.h:45
 msgid "_Close"
 msgstr "_Kapat"
 
-#: pdfarranger/pdfarranger.py:940
+#: pdfarranger/pdfarranger.py:942
 msgid "Save changes to “{}” before closing?"
 msgstr "Kapatmadan önce değişiklikler “{}” dosyasına kaydedilsin mi?"
 
-#: pdfarranger/pdfarranger.py:943
+#: pdfarranger/pdfarranger.py:945
 msgid "Save changes before closing?"
 msgstr "Kapatmadan önce değişiklikler kaydedilsin mi?"
 
-#: pdfarranger/pdfarranger.py:968
+#: pdfarranger/pdfarranger.py:970
 msgid "Discard changes and quit?"
 msgstr "Değişiklikler atılsın ve çıkılsın mı?"
 
-#: pdfarranger/pdfarranger.py:969 data/menu.ui.h:46
+#: pdfarranger/pdfarranger.py:971 data/menu.ui.h:46
 msgid "_Quit"
 msgstr "_Çık"
 
-#: pdfarranger/pdfarranger.py:974
+#: pdfarranger/pdfarranger.py:976
 msgid "Save changes to “{}” before quitting?"
 msgstr "Çıkmadan önce değişiklikler “{}” dosyasına kaydedilsin mi?"
 
-#: pdfarranger/pdfarranger.py:977
+#: pdfarranger/pdfarranger.py:979
 msgid "Save changes before quitting?"
 msgstr "Çıkmadan önce değişiklikler kaydedilsin mi?"
 
-#: pdfarranger/pdfarranger.py:1019
+#: pdfarranger/pdfarranger.py:1021
 msgid "Save As…"
 msgstr "Farklı Kaydet…"
 
-#: pdfarranger/pdfarranger.py:1019
+#: pdfarranger/pdfarranger.py:1021
 msgid "Export…"
 msgstr "Dışa Aktar…"
 
-#: pdfarranger/pdfarranger.py:1096
+#: pdfarranger/pdfarranger.py:1051 data/menu.ui.h:1
+msgid "_Open"
+msgstr "_Aç"
+
+#: pdfarranger/pdfarranger.py:1094
 msgid "Open…"
 msgstr "Aç…"
 
-#: pdfarranger/pdfarranger.py:1167
+#: pdfarranger/pdfarranger.py:1165
 msgid "Saving produced some warnings"
 msgstr "Kaydetme bazı uyarılar üretti"
 
-#: pdfarranger/pdfarranger.py:1168
+#: pdfarranger/pdfarranger.py:1166
 msgid "Despite the warnings the document(s) should have no visible issues."
 msgstr "Uyarılara rağmen belge(ler)de görünür sorun yoktur."
 
-#: pdfarranger/pdfarranger.py:1175
+#: pdfarranger/pdfarranger.py:1173
 msgid "Don't show warnings when saving again."
 msgstr "Kaydederken uyarıları yeniden gösterme."
 
-#: pdfarranger/pdfarranger.py:1205
+#: pdfarranger/pdfarranger.py:1203
 msgid "Saving…"
 msgstr "Kaydediliyor…"
 
-#: pdfarranger/pdfarranger.py:1239
+#: pdfarranger/pdfarranger.py:1237
 msgid "Import…"
 msgstr "İçe Aktar…"
 
-#: pdfarranger/pdfarranger.py:1333
+#: pdfarranger/pdfarranger.py:1331
 msgid "Pasted data not valid. Aborting paste."
 msgstr "Yapıştırılan veri geçersiz. Yapıştırılmıyor."
 
-#: pdfarranger/pdfarranger.py:1437
+#: pdfarranger/pdfarranger.py:1435
 msgid "PDF document is damaged"
 msgstr "PDF belgesi hasarlı"
 
-#: pdfarranger/pdfarranger.py:2298
+#: pdfarranger/pdfarranger.py:2296
 #, python-format
 msgid "%s is a tool for rearranging and modifying PDF files."
 msgstr ""
 "%s, PDF dosyalarını yeniden düzenlemek ve değiştirmek için bir araçtır."
 
-#: pdfarranger/pdfarranger.py:2301
+#: pdfarranger/pdfarranger.py:2299
 #, python-format
 msgid "It uses libqpdf %s, pikepdf %s, GTK %s and Python %s."
 msgstr "libqpdf %s, pikepdf %s, GTK %s ve Python %s kullanmaktadır."
 
-#: pdfarranger/pdfarranger.py:2307
+#: pdfarranger/pdfarranger.py:2305
 msgid "Maintainers and contributors"
 msgstr "Bakımcılar ve katkıcılar"
 
-#: pdfarranger/pdfarranger.py:2312
+#: pdfarranger/pdfarranger.py:2310
 msgid "GNU General Public License (GPL) Version 3."
 msgstr "GNU Genel Kamu Lisansı (GPL) Sürüm 3."
 
-#: pdfarranger/pdfarranger.py:2330
+#: pdfarranger/pdfarranger.py:2328
 msgid "Selected pages: "
 msgstr "Seçili sayfalar: "
 
-#: pdfarranger/pdfarranger.py:2335
+#: pdfarranger/pdfarranger.py:2333
 msgid "Page Size:"
 msgstr "Sayfa Boyutu:"
 
@@ -445,10 +451,6 @@ msgstr "Sola Döndür"
 #: data/pdfarranger.ui.h:9
 msgid "Rotate Right"
 msgstr "Sağa Döndür"
-
-#: data/menu.ui.h:1
-msgid "_Open"
-msgstr "_Aç"
 
 #: data/menu.ui.h:2
 msgid "_Import"


### PR DESCRIPTION
Changed "yükselik" to "yükseklik".