### PR TITLE
GHA: bump windows docker image

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -47,7 +47,7 @@ jobs:
   build-win32:
     runs-on: ubuntu-latest
     container:
-      image: jeromerobert/wine-mingw64:1.7.1
+      image: jeromerobert/wine-mingw64:1.8.0
       options: --user root
     steps:
     - uses: actions/checkout@v2

--- a/setup_win32.py
+++ b/setup_win32.py
@@ -116,6 +116,7 @@ required_gi_namespaces = [
     "Poppler-0.18",
     "HarfBuzz-0.0",
     "Handy-1",
+    "freetype2-2.0",
 ]
 
 for ns in required_gi_namespaces:


### PR DESCRIPTION
Upgrade Windows docker image to:
* pikepdf 6.2.5
* qpdf 11.2.0
* gtk 3.24.35

I did not tested the generated zip/msi that much and this needs to be done  before merging.

This should fix #719 