### PR TITLE
Bump GH actions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       PDFARRANGER_COVERAGE: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install
       run: pip3 install .[image]
     - name: AppStream
@@ -29,7 +29,7 @@ jobs:
     # PikePDF 6.0.1
     container: jeromerobert/pdfarranger-docker-ci:1.5.0
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install
       run: pip3 install .[image]
     - name: Tests
@@ -39,7 +39,7 @@ jobs:
     # PikePDF 1.19
     container: jeromerobert/pdfarranger-docker-ci:1.3.1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install
       run: pip3 install .[image]
     - name: Tests
@@ -50,15 +50,15 @@ jobs:
       image: jeromerobert/wine-mingw64:1.7.1
       options: --user root
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: ./setup.py build
     - run: HOME=/root wine python setup_win32.py bdist_msi
     - run: HOME=/root wine python setup_win32.py bdist_zip
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: pdfarranger-windows-installer-msi
         path: dist/*.msi
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: pdfarranger-windows-portable-zip
         path: dist/*.zip
@@ -68,7 +68,7 @@ jobs:
     steps:
     - name: RPM Build
       run: /pdfarranger/pdfarranger-build
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: pdfarranger-fedora-testbuild
         path: /github/home/rpmbuild/**/*.rpm


### PR DESCRIPTION
Fix warnings about Node.js 12 actions being deprecated

Let's run the CI and see how it works...