### PR TITLE
Fix typos

### DIFF
--- a/pdfarranger.spec
+++ b/pdfarranger.spec
@@ -163,7 +163,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
 
 * Wed Sep 11 2019 David Auer <dreua@posteo.de> - 1.3.0-2
 - Add missing dependency
-- Remove unnecessary python_provide makro
+- Remove unnecessary python_provide macro
 
 * Sun Aug 11 2019 David Auer <dreua@posteo.de> - 1.3.0-1
 - New version, see https://github.com/jeromerobert/pdfarranger/releases/tag/1.3.0
@@ -184,7 +184,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
 - Fix rpmlint errors and warnings
 
 * Sat May 18 2019 David Auer <dreua@posteo.de> - 1.2.1-4
-- Buiding with wheel to get lang and icons right
+- Building with wheel to get lang and icons right
 
 * Sat May 18 2019 David Auer <dreua@posteo.de> - 1.2.1-3
 - Move Requires to the right location

--- a/pdfarranger/metadata.py
+++ b/pdfarranger/metadata.py
@@ -28,10 +28,10 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 _ = gettext.gettext
 
-# The producer property can be overriden by pikepdf
+# The producer property can be overridden by pikepdf
 PRODUCER = '{http://ns.adobe.com/pdf/1.3/}Producer'
 # Currently the only property which support lists as values. If you add more
-# please implement a generic mecanism.
+# please implement a generic mechanism.
 _CREATOR = '{http://purl.org/dc/elements/1.1/}creator'
 _CREATED = '{http://ns.adobe.com/xap/1.0/}CreateDate'
 _MODIFIED = '{http://ns.adobe.com/xap/1.0/}ModifyDate'
@@ -191,7 +191,7 @@ def edit(metadata, pdffiles, parent):
     """
     Edit the current meta data
 
-    :param metadata: The dictionnary of meta data to modify
+    :param metadata: The dictionary of meta data to modify
     :param pdffiles: A list of PDF from witch to take the initial meta data
     :param parent: The parent window
     """

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -502,7 +502,7 @@ class PdfArranger(Gtk.Application):
 
     def do_activate(self):
         """ https://lazka.github.io/pgi-docs/Gio-2.0/classes/Application.html#Gio.Application.do_activate """
-        # TODO: huge method that should be splitted
+        # TODO: huge method that should be split
 
         iconsdir = os.path.join(sharedir, 'icons')
         if not os.path.exists(iconsdir):
@@ -1019,7 +1019,7 @@ class PdfArranger(Gtk.Application):
         self.iconview.unselect_all()
         self.iconview.get_model().clear()
 
-        # Release Poppler.Document instances to unlock all temporay files
+        # Release Poppler.Document instances to unlock all temporary files
         self.pdfqueue = []
         gc.collect()
         self.config.set_window_size(self.window.get_size())

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ import tempfile
 import shutil
 
 """
-Thoses tests are using Dogtail https://gitlab.com/dogtail/dogtail
+Those tests are using Dogtail https://gitlab.com/dogtail/dogtail
 
 Other tools using dogtail where you can get example on how to use it:
 
@@ -29,7 +29,7 @@ treeview.keyCombo('<ctrl>L')
 treeview.typeText('qpdf-manual.pdf')
 filechooser.button('Open').click()
 
-You may need to run the following commands to run thoses tests in your current session instead of Xvfb:
+You may need to run the following commands to run those tests in your current session instead of Xvfb:
 
 * /usr/libexec/at-spi-bus-launcher --launch-immediately
 * setxkbmap -v fr
@@ -187,7 +187,7 @@ class PdfArrangerTest(unittest.TestCase):
         app = self._app()
         from dogtail import predicate
         allstatusbar = app.findChildren(predicate.GenericPredicate(roleName="status bar"), showingOnly=False)
-        # If we have multiple status bar, concider the last one as the one who display the selection
+        # If we have multiple status bar, consider the last one as the one who display the selection
         statusbar = allstatusbar[-1]
         return statusbar.name
 


### PR DESCRIPTION
Found via `codespell -S po,.mypy_cache -L te`