### PR TITLE
Fix missing lang tag in metainfo

### DIFF
--- a/data/com.github.jeromerobert.pdfarranger.metainfo.xml
+++ b/data/com.github.jeromerobert.pdfarranger.metainfo.xml
@@ -125,7 +125,7 @@ See file COPYING or go to <http://www.gnu.org/licenses/> for full license detail
       bijgesneden, opgesplitst en pagina's worden herordend, allemaal vanuit een intuïtief,
       grafisch venster.
     </p>
-    <p>
+    <p xml:lang="nl">
       Het is een frontend voor pikepdf.
     </p>
 


### PR DESCRIPTION
This paragraph showed up in the english summary on flathub: https://flathub.org/apps/details/com.github.jeromerobert.pdfarranger