### PR TITLE
Make Handy a hard dependency and port preferences dialog to HdyPreferencesWindow

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -37,7 +37,7 @@ jobs:
   build-old-pikepdf:
     runs-on: ubuntu-latest
     # PikePDF 1.19
-    container: jeromerobert/pdfarranger-docker-ci:1.3.1
+    container: jeromerobert/pdfarranger-docker-ci:1.3.2
     steps:
     - uses: actions/checkout@v3
     - name: Install

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ sudo pacman -S poppler-glib python-distutils-extra python-pip \
 
 ```
 sudo dnf install poppler-glib python3-distutils-extra python3-pip python3-gobject \
-    gtk3 python3-cairo python3-wheel python3-pikepdf python3-img2pdf python3-dateutil
+    gtk3 python3-cairo python3-wheel python3-pikepdf python3-img2pdf python3-dateutil libhandy
 ```
 
 **On FreeBSD**
 
 ```
 sudo pkg install devel/gettext devel/py-gobject3 devel/py-pip devel/py-python-distutils-extra \
-    graphics/poppler-glib textproc/intltool textproc/py-pikepdf x11-toolkits/gtk30
+    graphics/poppler-glib textproc/intltool textproc/py-pikepdf x11-toolkits/gtk30 x11-toolkits/libhandy
 ```
 
 **Then**

--- a/data/pdfarranger.ui
+++ b/data/pdfarranger.ui
@@ -18,10 +18,14 @@ You should have received a copy of the GNU General Public License
 along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <object class="GtkApplicationWindow" id="main_window">
+  <object class="HdyApplicationWindow" id="main_window">
     <property name="show_menubar">False</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="header_bar">
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="orientation">vertical</property>
+    <child>
+      <object class="HdyHeaderBar" id="header_bar">
         <property name="visible">True</property>
         <property name="spacing">4</property>
         <property name="show_close_button">True</property>
@@ -258,6 +262,7 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
       <object class="GtkBox" id="main_box">
         <property name="visible">True</property>
         <property name="orientation">vertical</property>
+        <property name="expand">True</property>
         <child>
           <object class="GtkScrolledWindow" id="scrolledwindow">
             <property name="visible">True</property>
@@ -329,4 +334,6 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
       </object>
     </child>
   </object>
+      </child>
+    </object>
 </interface>

--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="HdyPreferencesWindow" id="prefs_window">
+    <property name="title" translatable="yes">Preferences</property>
+    <property name="search-enabled">False</property>
+    <child>
+      <object class="HdyPreferencesPage">
+        <property name="visible">True</property>
+        <child>
+          <object class="HdyPreferencesGroup">
+            <property name="visible">True</property>
+            <child>
+              <object class="HdyComboRow" id="langs_combo_row">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes">Language</property>
+                <property name="subtitle" translatable="yes">Requires restart</property>
+              </object>
+            </child>
+            <child>
+              <object class="HdyComboRow" id="theme_combo_row">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes">Theme</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pdfarranger/config.py
+++ b/pdfarranger/config.py
@@ -207,7 +207,7 @@ class Config(object):
             if k != "enable_custom"
         ]
 
-    def preferences_dialog(self, parent, localedir, handy_available):
+    def preferences_dialog(self, parent, localedir):
         """A dialog where language and theme can be selected."""
         d = Gtk.Dialog(title=_("Preferences"),
                        parent=parent,
@@ -228,9 +228,7 @@ class Config(object):
         hbox2 = Gtk.Box(spacing=6, margin=8)
         frame2 = Gtk.Frame(label=_("Theme"), margin=8)
         combo2 = Gtk.ComboBoxText(margin=8)
-        label2 = Gtk.Label("" if handy_available else _("(Libhandy missing)"))
         hbox2.pack_start(combo2, False, False, 8)
-        hbox2.pack_start(label2, False, False, 8)
         frame2.add(hbox2)
         d.vbox.pack_start(frame2, False, False, 8)
 
@@ -255,7 +253,6 @@ class Config(object):
             combo2.set_active(themes.index(theme))
         else:
             combo2.set_active(0)
-        combo2.set_sensitive(handy_available)
 
         d.show_all()
         result = d.run()

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -83,7 +83,6 @@ VERSION = '1.9.2'
 WEBSITE = 'https://github.com/pdfarranger/pdfarranger'
 
 if os.name == 'nt':
-    import darkdetect
     import keyboard  # to get control key state when drag to other instance
     # Add support for dnd to other instance and insert file at drop location in Windows
     os.environ['GDK_WIN32_USE_EXPERIMENTAL_OLE2_DND'] = 'true'
@@ -313,21 +312,6 @@ class PdfArranger(Gtk.Application):
             f = '/usr/local/share/{}/{}'.format(DOMAIN, path)
         return f
 
-    def set_color_scheme(self):
-        try:
-            scheme = Handy.ColorScheme.PREFER_LIGHT
-            if os.name == 'nt' and darkdetect.isDark():
-                scheme = Handy.ColorScheme.PREFER_DARK
-            theme = self.config.theme()
-            if theme == 'dark':
-                scheme = Handy.ColorScheme.FORCE_DARK
-            elif theme == 'light':
-                scheme = Handy.ColorScheme.FORCE_LIGHT
-            Handy.StyleManager.get_default().set_color_scheme(scheme)
-        except AttributeError:
-            # This libhandy is too old. 1.5.90 needed ?
-            pass
-
     def __create_main_window(self):
         """Create the Handy.ApplicationWindow"""
         b = Gtk.Builder()
@@ -339,7 +323,7 @@ class PdfArranger(Gtk.Application):
         b.connect_signals(self)
         self.uiXML = b
         self.window = self.uiXML.get_object("main_window")
-        self.set_color_scheme()
+        self.config.set_color_scheme()
         self.window.set_default_icon_name(ICON_ID)
         return b
 
@@ -458,8 +442,7 @@ class PdfArranger(Gtk.Application):
         self.silent_render()
 
     def on_action_preferences(self, _action, _option, _unknown):
-        self.config.preferences_dialog(self.window, localedir)
-        self.set_color_scheme()
+        self.config.preferences_window(self.window, self.__resource_path, localedir)
 
     def on_action_print(self, _action, _option, _unknown):
         exporter.PrintOperation(self).run()

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,3 +3,4 @@ pdfarranger/metadata.py
 pdfarranger/pageutils.py
 data/pdfarranger.ui
 data/menu.ui
+data/preferences.ui

--- a/po/genpot.sh
+++ b/po/genpot.sh
@@ -24,5 +24,6 @@
 cd "$(dirname "$0")/.."
 intltool-extract --type=gettext/glade data/pdfarranger.ui
 intltool-extract --type=gettext/glade data/menu.ui
+intltool-extract --type=gettext/glade data/preferences.ui
 xgettext --from-code=utf-8 --language=Python --keyword=_ --keyword=N_ --output=po/pdfarranger.pot \
-  pdfarranger/*.py data/pdfarranger.ui.h data/menu.ui.h
+  pdfarranger/*.py data/pdfarranger.ui.h data/menu.ui.h data/preferences.ui.h

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from DistUtilsExtra.command import (
 
 data_files = [
     ('share/applications', ['data/com.github.jeromerobert.pdfarranger.desktop']),
-    ('share/pdfarranger', ['data/pdfarranger.ui', 'data/menu.ui']),
+    ('share/pdfarranger', ['data/pdfarranger.ui', 'data/menu.ui', 'data/preferences.ui']),
     ('share/man/man1', ['doc/pdfarranger.1']),
     ('share/metainfo', ['data/com.github.jeromerobert.pdfarranger.metainfo.xml']),
 ]

--- a/setup_win32.py
+++ b/setup_win32.py
@@ -11,6 +11,7 @@ import pkg_resources
 include_files = [
     ('data/pdfarranger.ui', 'share/pdfarranger/pdfarranger.ui'),
     ('data/menu.ui', 'share/pdfarranger/menu.ui'),
+    ('data/preferences.ui', 'share/pdfarranger/preferences.ui'),
     ('data/icons/hicolor/scalable', 'share/icons/hicolor/scalable'),
     ('build/mo', 'share/locale'),
 ]


### PR DESCRIPTION
Since version 1.6 is now [available](https://packages.ubuntu.com/jammy/gir1.2-handy-1) in the LTS version of Ubuntu, it is no longer necessary to add a PPA. Related #651

Preferences window widgets are now in an UI file, languages and theme preferences options are now stored in GListStore.

Window height and width are not modified since there are some visual glitches in Windows with HdyComboRow popover when window height is around 350 or lower.

![imagen](https://user-images.githubusercontent.com/42654671/226191109-25e29cb4-4fec-471a-8e74-8063d20817c4.png)