### PR TITLE
No longer use python-distutils-extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,29 +46,28 @@ Pip will automatically install the latest pikepdf if there is no pikepdf install
 **On Debian-based distributions**
 
 ```
-sudo apt-get install python3-pip python3-distutils-extra python3-wheel python3-gi \
-    python3-gi-cairo gir1.2-gtk-3.0 gir1.2-poppler-0.18 gir1.2-handy-1 python3-setuptools
+sudo apt-get install python3-pip python3-wheel python3-gi python3-gi-cairo \
+    gir1.2-gtk-3.0 gir1.2-poppler-0.18 gir1.2-handy-1 python3-setuptools
 ```
 
 **On Arch Linux**
 
 ```
-sudo pacman -S poppler-glib python-distutils-extra python-pip \
-    python-gobject gtk3 python-cairo libhandy
+sudo pacman -S poppler-glib python-pip python-gobject gtk3 python-cairo libhandy
 ```
 
 **On Fedora**
 
 ```
-sudo dnf install poppler-glib python3-distutils-extra python3-pip python3-gobject \
-    gtk3 python3-cairo python3-wheel python3-pikepdf python3-img2pdf python3-dateutil libhandy
+sudo dnf install poppler-glib python3-pip python3-gobject gtk3 python3-cairo \
+    python3-wheel python3-pikepdf python3-img2pdf python3-dateutil libhandy
 ```
 
 **On FreeBSD**
 
 ```
-sudo pkg install devel/gettext devel/py-gobject3 devel/py-pip devel/py-python-distutils-extra \
-    graphics/poppler-glib textproc/intltool textproc/py-pikepdf x11-toolkits/gtk30 \
+sudo pkg install devel/gettext devel/py-gobject3 devel/py-pip \
+    graphics/poppler-glib textproc/py-pikepdf x11-toolkits/gtk30 \
     x11-toolkits/libhandy
 ```
 

--- a/Win32.md
+++ b/Win32.md
@@ -22,13 +22,12 @@ pacman -S mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python-gobject \
  mingw-w64-x86_64-python-lxml mingw-w64-x86_64-qpdf mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext mingw-w64-x86_64-gnutls mingw-w64-x86_64-python-pillow \
  mingw-w64-x86_64-python-dateutil mingw-w64-x86_64-python-pip mingw-w64-x86_64-libhandy \
- mingw-w64-x86_64-python-setuptools-scm git python-pip intltool
+ mingw-w64-x86_64-python-setuptools-scm git python-pip
 ```
 
 and
 
 ```
-pip install --user https://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
 /mingw64/bin/python3 -m pip install --user keyboard darkdetect https://github.com/jeromerobert/cx_Freeze/zipball/pdfarranger
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[build_icons]
-icon-dir=data/icons/hicolor


### PR DESCRIPTION
* python-distutils-extra was added by 2077a73
* it relies on intltool which is deprecated as gettext can now do the job alone
* intltool relies on perl which is a tricky dependency on Windows
* PyPA has announced disruptive changes to distutils/setuptools/pip that will propably break python-distutils-extra
* clean_i18n is removed as it was not very useful
* Close #853