### PR TITLE
Update 'selected pages' after merge_pages()

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -2417,6 +2417,7 @@ class PdfArranger(Gtk.Application):
                     break
             ndpage += 1
         self.update_iconview_geometry()
+        self.iv_selection_changed_event()
         self.update_max_zoom_level()
 
     def edit_metadata(self, _action, _parameter, _unknown):


### PR DESCRIPTION
This fixes two inconsistencies with `merge_pages()`

1) If all pages of a document are selected and merged with preselected knobs, the total page count goes to zero.
![image](https://github.com/pdfarranger/pdfarranger/assets/17718454/83d745b0-ece0-4c5f-9c11-a8606c238116)

2) If a subset of pages are merged, the page count is updated, but the displayed _Selected pages_ is not.
![image](https://github.com/pdfarranger/pdfarranger/assets/17718454/eba19c37-7db6-4698-aea6-05b929b8786f)
