### PR TITLE
Add control and display_length tags to metainfo

### DIFF
--- a/data/com.github.jeromerobert.pdfarranger.metainfo.xml
+++ b/data/com.github.jeromerobert.pdfarranger.metainfo.xml
@@ -186,4 +186,12 @@ See file COPYING or go to <http://www.gnu.org/licenses/> for full license detail
   </releases>
   <project_license>GPL-3.0-or-later</project_license>
   <url type="bugtracker">https://github.com/pdfarranger/pdfarranger/issues</url>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+  <requires>
+    <display_length compare="ge">520</display_length>
+  </requires>
 </component>


### PR DESCRIPTION
Gives more information to users of software management tools such as GNOME Software. [AppStream docs](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html).

| Current    | These changes      |
|---------------------|------------------------|
| ![](https://github.com/pdfarranger/pdfarranger/assets/42654671/02261874-21c7-4ac2-8aba-9004aa797173) | ![](https://github.com/pdfarranger/pdfarranger/assets/42654671/5fa2c414-d65f-4025-9286-e8eeb8c82231) |