### PR TITLE
Harden pikepdf version checking

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -24,6 +24,7 @@ import tempfile
 import io
 import gi
 import locale
+import packaging.version as version
 from . import metadata
 from gi.repository import Gtk
 gi.require_version("Poppler", "0.18")
@@ -447,7 +448,7 @@ def generate_booklet(pdfqueue, tmp_dir, pages):
             )
 
         # workaround for pikepdf <= 2.6.0. See https://github.com/pikepdf/pikepdf/issues/174
-        if pikepdf.__version__ < '2.7.0':
+        if version.parse(pikepdf.__version__) < version.Version('2.7.0'):
             newpage = file.make_indirect(newpage)
         file.pages.append(newpage)
     for __ in range(to_remove):

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -400,6 +400,7 @@ def num_pages(filepath):
 
 
 def generate_booklet(pdfqueue, tmp_dir, pages):
+    pre_pike_2_7 = version.parse(pikepdf.__version__) < version.Version('2.7.0')
     file, filename = make_tmp_file(tmp_dir)
     content_dict = pikepdf.Dictionary({})
     file_indexes = set()
@@ -448,7 +449,7 @@ def generate_booklet(pdfqueue, tmp_dir, pages):
             )
 
         # workaround for pikepdf <= 2.6.0. See https://github.com/pikepdf/pikepdf/issues/174
-        if version.parse(pikepdf.__version__) < version.Version('2.7.0'):
+        if pre_pike_2_7:
             newpage = file.make_indirect(newpage)
         file.pages.append(newpage)
     for __ in range(to_remove):

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
     entry_points={
         'console_scripts': ['pdfarranger=pdfarranger.pdfarranger:main']
     },
-    install_requires=['pikepdf>=1.17.0','python-dateutil>=2.4.0'],
+    install_requires=['pikepdf>=1.17.0','python-dateutil>=2.4.0', 'packaging'],
     extras_require={
         'image': ['img2pdf>=0.3.4'],
     },


### PR DESCRIPTION
Avoid future problems with eg 10.0.0 testing as less than 8.0.0.