### PR TITLE
Fix error on export of page with overlay with Pikepdf >= 8

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -391,7 +391,7 @@ def _transform_job(pdf_output: pikepdf.Pdf, pages: List[Page], quit_flag = None)
     # # Add overlays and underlays
     for i, page in enumerate(pages):
         # The dest page coordinates and size before geometrical transformations
-        dx1, dy1, dx2, dy2 = mediaboxes[i]
+        dx1, dy1, dx2, dy2 = [float(m) for m in mediaboxes[i]]
         dw, dh = dx2 - dx1, dy2 - dy1
 
         # Call to rotate in _apply_geom_transform_job ensures /Rotate exists


### PR DESCRIPTION
To reproduce:
1. Open a pdf
2. Scale a page to 25%
3. Export the scaled page
4. Close all, crtl +W
5. Import the exported pdf
6. Copy the page and paste it as overlay on itself
7. Export the page

This is the output:
```
Traceback (most recent call last):
  File "/mnt/evo860/Python/pdfarranger/pdfarranger/exporter.py", line 275, in wrapper
    func(*args, **kwargs)
  File "/mnt/evo860/Python/pdfarranger/pdfarranger/exporter.py", line 525, in export
    export_doc_job(pdf_input, files, pages, mdata, files_out, quit_flag, test_mode)
  File "/mnt/evo860/Python/pdfarranger/pdfarranger/exporter.py", line 496, in export_doc_job
    _transform_job(pdf_output, pages, quit_flag)
  File "/mnt/evo860/Python/pdfarranger/pdfarranger/exporter.py", line 403, in _transform_job
    x1 = page.scale * (dx1 + dw * offs_left)
TypeError: unsupported operand type(s) for *: 'decimal.Decimal' and 'float'
```
