### PR TITLE
Add doctest to Sides.rotated

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -69,7 +69,16 @@ class Sides(NamedTuple):
     bottom: Numeric = 0
 
     def rotated(self, times: int) -> "Sides":
-        """Rotate 90 degrees counter-clockwise 'times' times"""
+        """
+        Rotate 90 degrees counter-clockwise 'times' times
+
+        Examples:
+
+        >>> Sides(9,3,12,6).rotated(1)
+        Sides(left=12, right=6, top=3, bottom=9)
+        >>> Sides(9,3,12,6).rotated(-3) == Sides(9,3,12,6).rotated(1)
+        True
+        """
         perm = (0, 2, 1, 3)
         return Sides(*(self[perm[(x + times) % 4]] for x in perm))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,54 +1,55 @@
+import doctest
 import unittest
 
-from pdfarranger.core import LayerPage as LPage
-from pdfarranger.core import Dims, Page, Sides
+import pdfarranger.core as core
 
 
 class PTest(unittest.TestCase):
     """Base class for Page and LayerPage tests"""
 
     @staticmethod
-    def _lpage1() -> LPage:
+    def _lpage1() -> core.LayerPage:
         """Sample layer page 1"""
-        return LPage(2, 4, 'lcopy', 90, 2, Sides(0.11, 0.21, 0.31, 0.41), Sides(0.12, 0.22, 0.32, 0.42), 'OVERLAY',
-                     Dims(10.33, 20.33))
+        return core.LayerPage(2, 4, 'lcopy', 90, 2, core.Sides(0.11, 0.21, 0.31, 0.41),
+                              core.Sides(0.12, 0.22, 0.32, 0.42), 'OVERLAY', core.Dims(10.33, 20.33))
 
     @staticmethod
-    def _lpage1_90() -> LPage:
+    def _lpage1_90() -> core.LayerPage:
         """Sample layer page 1 rotated 90 degrees"""
-        return LPage(2, 4, 'lcopy', 180, 2, Sides(0.41, 0.31, 0.11, 0.21), Sides(0.42, 0.32, 0.12, 0.22), 'OVERLAY',
-                     Dims(10.33, 20.33))
+        return core.LayerPage(2, 4, 'lcopy', 180, 2, core.Sides(0.41, 0.31, 0.11, 0.21),
+                              core.Sides(0.42, 0.32, 0.12, 0.22), 'OVERLAY', core.Dims(10.33, 20.33))
 
     @staticmethod
-    def _lpage1_180() -> LPage:
+    def _lpage1_180() -> core.LayerPage:
         """Sample layer page 1 rotated 180 degrees"""
-        return LPage(2, 4, 'lcopy', 270, 2, Sides(0.21, 0.11, 0.41, 0.31), Sides(0.22, 0.12, 0.42, 0.32), 'OVERLAY',
-                     Dims(10.33, 20.33))
+        return core.LayerPage(2, 4, 'lcopy', 270, 2, core.Sides(0.21, 0.11, 0.41, 0.31),
+                              core.Sides(0.22, 0.12, 0.42, 0.32), 'OVERLAY', core.Dims(10.33, 20.33))
 
     @staticmethod
-    def _lpage1_270() -> LPage:
+    def _lpage1_270() -> core.LayerPage:
         """Sample layer page 1 rotated 180 degrees"""
-        return LPage(2, 4, 'lcopy', 0, 2, Sides(0.31, 0.41, 0.21, 0.11), Sides(0.32, 0.42, 0.22, 0.12), 'OVERLAY',
-                     Dims(10.33, 20.33))
+        return core.LayerPage(2, 4, 'lcopy', 0, 2, core.Sides(0.31, 0.41, 0.21, 0.11),
+                              core.Sides(0.32, 0.42, 0.22, 0.12), 'OVERLAY', core.Dims(10.33, 20.33))
 
-    def _page1(self) -> Page:
+    def _page1(self) -> core.Page:
         """Sample page 1"""
-        return Page(1, 2, 0.55, 'copy', 0, 2, Sides(0.1, 0.2, 0.3, 0.4), Dims(100.33, 200.66), 'base', [self._lpage1()])
+        return core.Page(1, 2, 0.55, 'copy', 0, 2, core.Sides(0.1, 0.2, 0.3, 0.4), core.Dims(100.33, 200.66), 'base',
+                         [self._lpage1()])
 
-    def _page1_90(self) -> Page:
+    def _page1_90(self) -> core.Page:
         """Sample page 1 rotated 90 degrees"""
-        return Page(1, 2, 0.55, 'copy', 90, 2, Sides(0.4, 0.3, 0.1, 0.2), Dims(100.33, 200.66), 'base',
-                    [self._lpage1_90()])
+        return core.Page(1, 2, 0.55, 'copy', 90, 2, core.Sides(0.4, 0.3, 0.1, 0.2), core.Dims(100.33, 200.66), 'base',
+                         [self._lpage1_90()])
 
-    def _page1_180(self) -> Page:
+    def _page1_180(self) -> core.Page:
         """Sample page 1 rotated 90 degrees"""
-        return Page(1, 2, 0.55, 'copy', 180, 2, Sides(0.2, 0.1, 0.4, 0.3), Dims(100.33, 200.66), 'base',
-                    [self._lpage1_180()])
+        return core.Page(1, 2, 0.55, 'copy', 180, 2, core.Sides(0.2, 0.1, 0.4, 0.3), core.Dims(100.33, 200.66), 'base',
+                         [self._lpage1_180()])
 
-    def _page1_270(self) -> Page:
+    def _page1_270(self) -> core.Page:
         """Sample page 1 rotated 90 degrees"""
-        return Page(1, 2, 0.55, 'copy', 270, 2, Sides(0.3, 0.4, 0.2, 0.1), Dims(100.33, 200.66), 'base',
-                    [self._lpage1_270()])
+        return core.Page(1, 2, 0.55, 'copy', 270, 2, core.Sides(0.3, 0.4, 0.2, 0.1), core.Dims(100.33, 200.66), 'base',
+                         [self._lpage1_270()])
 
 
 class BasePageTest(PTest):
@@ -67,16 +68,16 @@ class BasePageTest(PTest):
     def test02(self):
         """Test rotate_times"""
         #  Remember - counter-clockwise !
-        self.assertEqual(Page.rotate_times(0), 0)
-        self.assertEqual(Page.rotate_times(90), 3)
-        self.assertEqual(Page.rotate_times(134), 3)
-        self.assertEqual(Page.rotate_times(-270), 3)
-        self.assertEqual(Page.rotate_times(3690), 3)
+        self.assertEqual(core.Page.rotate_times(0), 0)
+        self.assertEqual(core.Page.rotate_times(90), 3)
+        self.assertEqual(core.Page.rotate_times(134), 3)
+        self.assertEqual(core.Page.rotate_times(-270), 3)
+        self.assertEqual(core.Page.rotate_times(3690), 3)
 
 
 class PageTest(PTest):
 
-    def _rotate(self, angle: int) -> Page:
+    def _rotate(self, angle: int) -> core.Page:
         """Return sample page 1 rotated by angle"""
         p = self._page1()
         p.rotate(angle)
@@ -91,10 +92,10 @@ class PageTest(PTest):
         self.assertEqual(repr(self._rotate(-270)), repr(self._page1_90()))
         self.assertEqual(repr(self._rotate(180)), repr(self._page1_180()))
         self.assertEqual(repr(self._rotate(270)), repr(self._page1_270()))
-        self.assertEqual(self._rotate(0).size, Dims(100.33, 200.66))
-        self.assertEqual(self._rotate(90).size, Dims(200.66, 100.33))
-        self.assertEqual(self._rotate(180).size, Dims(100.33, 200.66))
-        self.assertEqual(self._rotate(270).size, Dims(200.66, 100.33))
+        self.assertEqual(self._rotate(0).size, core.Dims(100.33, 200.66))
+        self.assertEqual(self._rotate(90).size, core.Dims(200.66, 100.33))
+        self.assertEqual(self._rotate(180).size, core.Dims(100.33, 200.66))
+        self.assertEqual(self._rotate(270).size, core.Dims(200.66, 100.33))
 
     def test02(self):
         """Test duplicate"""
@@ -127,7 +128,7 @@ class PageTest(PTest):
 
 class LayerPageTest(PTest):
 
-    def _rotate(self, angle: int) -> LPage:
+    def _rotate(self, angle: int) -> core.LayerPage:
         """Return sample layer page 1 rotated by angle"""
         p = self._lpage1()
         p.rotate(angle)
@@ -142,10 +143,10 @@ class LayerPageTest(PTest):
         self.assertEqual(repr(self._rotate(3)), repr(self._lpage1_90()))
         self.assertEqual(repr(self._rotate(-2)), repr(self._lpage1_180()))
         self.assertEqual(repr(self._rotate(-3)), repr(self._lpage1_270()))
-        self.assertEqual(self._rotate(0).size, Dims(20.33, 10.33))
-        self.assertEqual(self._rotate(-1).size, Dims(10.33, 20.33))
-        self.assertEqual(self._rotate(-2).size, Dims(20.33, 10.33))
-        self.assertEqual(self._rotate(-3).size, Dims(10.33, 20.33))
+        self.assertEqual(self._rotate(0).size, core.Dims(20.33, 10.33))
+        self.assertEqual(self._rotate(-1).size, core.Dims(10.33, 20.33))
+        self.assertEqual(self._rotate(-2).size, core.Dims(20.33, 10.33))
+        self.assertEqual(self._rotate(-3).size, core.Dims(10.33, 20.33))
 
     def test02(self):
         """Test duplicate"""
@@ -160,3 +161,8 @@ class LayerPageTest(PTest):
         """Test serialize"""
         self.assertEqual(self._lpage1().serialize(),
                          'lcopy\n4\n90\n2\nOVERLAY\n0.11\n0.21\n0.31\n0.41\n0.12\n0.22\n0.32\n0.42')
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(core))
+    return tests

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -45,10 +45,6 @@ class LayerPage:
     size_orig: Dims = Dims(612, 792)
     layerpages: List[Any] = field(default_factory=list)
 
-    @staticmethod
-    def rotate_array(array: Sides, rotate_times: int) -> Sides:
-        return LPage.rotate_array(array, rotate_times)
-
 
 class ExporterTest(unittest.TestCase):
 


### PR DESCRIPTION
@jeromerobert 

> I would like to avoid to have too many unit tests (i.e. which test low-level functions). My experience is that it make refactoring a nightmare. 

I guess it depends on how familiar you are with the code. I tend to view tests as executable documentation and as someone with a vague acquaintance with PdfArranger I tend to write unit tests before refactoring code to make sure I understand the intend of the existing code. From my perspective, executable documentation makes the learning curve of contributing less steep.

What would be your view on using executable examples as in Sides.rotated as a reasonable compromise between aiding new contributors and keeping refactoring straightforward?