### PR TITLE
dogtail test: paste page with overlay as underlay

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -487,25 +487,37 @@ class TestBatch2(PdfArrangerTest):
         dialog.child(name="OK").click()
         self._wait_cond(lambda: dialog.dead)
 
-    def test_05_export(self):
+    def test_05_past_underlay(self):
+        """Past a page with overlay under an other page"""
+        if not have_pikepdf3():
+            return
+        app = self._app()
+        app.keyCombo("<ctrl>c")
+        app.keyCombo("Left")
+        app.keyCombo("<shift><ctrl>u")
+        dialog = self._app().child(roleName="dialog")
+        dialog.child(name="OK").click()
+        self._wait_cond(lambda: dialog.dead)
+
+    def test_06_export(self):
         self._mainmenu(["Export", "Export All Pages to Individual Files…"])
         self._save_as_chooser(
             "alltosingle.pdf", ["alltosingle.pdf", "alltosingle-002.pdf"]
         )
-        self._assert_file_size("alltosingle.pdf", 1219)
+        self._assert_file_size("alltosingle.pdf", 1814 if have_pikepdf3() else 1219)
         self._assert_file_size("alltosingle-002.pdf", 1544 if have_pikepdf3() else 1219)
 
-    def test_06_clear(self):
+    def test_07_clear(self):
         self._popupmenu(1, "Delete")
         self.assertEqual(len(self._icons()), 1)
 
-    def test_07_about(self):
+    def test_08_about(self):
         self._mainmenu("About")
         dialog = self._app().child(roleName="dialog")
         dialog.child(name="Close").click()
         self._wait_cond(lambda: dialog.dead)
 
-    def test_08_quit(self):
+    def test_09_quit(self):
         self._quit_without_saving()
 
 


### PR DESCRIPTION
The lines `lp.crop[i] +=`  and `lp.offset[i] +=`  cause `"TypeError: 'Sides' object does not support item assignment"`
To test this code you need to copy and paste as overlay a page which already has a overlay.

_Originally posted by @kbengs in https://github.com/pdfarranger/pdfarranger/pull/957#discussion_r1308133936_

Detect a regression in #957 

@m-holger any opinion on how to fix it ?