### PR TITLE
Fix reversion in #950

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -839,7 +839,7 @@ class PDFRenderer(threading.Thread, GObject.GObject):
             if rotation > 0:
                 cr.translate(*p.size.scaled(0.5))
                 cr.rotate(rotation * pi / 180)
-                cr.translate(*p.size.scaled(-0.5))
+                cr.translate(*p.size_orig.scaled(-0.5))
             self.render(cr, p)
             cr.restore()
             self.add_layers(cr, p, layer='OVERLAY')


### PR DESCRIPTION
To reproduce:
- open tests/test.pdf
- rotate page 2
- duplicate page 1
-  undo

Page 2 is not rendered correctly