### PR TITLE
Support both new setuptools and old distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,14 @@
 
 from setuptools import Command
 from setuptools import setup
-# for the time being do not use setuptools.command because:
-# * setuptools is to old in many distro (ex: Ubuntu 22.04)
-# * The Fedora package relies on wheel so it would not contains translation and
-#   icons
-from distutils.command.build import build
+from setuptools import __version__ as setuptools_version
+
+# support distros that ship old setuptools
+setuptools_version = tuple(int(n) for n in setuptools_version.split('.')[:2])
+if setuptools_version < (65, 2):
+    from distutils.command.build import build
+else:
+    from setuptools.command.build import build
 
 from os.path import join
 import glob


### PR DESCRIPTION
- Old distros still didn’t update their setuptools and we still want to build for them
- New/rolling distros officially deprecated distutils

This works for both setups without deprecations/warnings.