### PR TITLE
Use cropped page size in "Page size" dialog

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -2464,9 +2464,9 @@ class PdfArranger(Gtk.Application):
         newscale = diag.run_get()
         if newscale is None:
             return
+        self.undomanager.commit("Size")
         if not pageutils.scale(self.model, selection, newscale):
             return
-        self.undomanager.commit("Size")
         self.set_unsaved(True)
         self.update_statusbar()
         self.update_iconview_geometry()


### PR DESCRIPTION
The width or height of the page in the "Page size" dialog will not be the width or height of the page if it is cropped. I think that is not as expected. The statusbar also show the cropped size.