### PR TITLE
Fix iconview in right-to-left locale

### DIFF
--- a/pdfarranger/iconview.py
+++ b/pdfarranger/iconview.py
@@ -171,9 +171,15 @@ class IconviewCursor(object):
             step = 0 if self.cursor_page_nr + columns_nr > len(self.model) - 1 else columns_nr
             self.cursor_page_nr_new = self.cursor_page_nr + step
         elif self.event.keyval == Gdk.KEY_Left:
-            self.cursor_page_nr_new = max(self.cursor_page_nr - 1, 0)
+            if self.iconview.get_direction() == Gtk.TextDirection.LTR:
+                self.cursor_page_nr_new = max(self.cursor_page_nr - 1, 0)
+            else:
+                self.cursor_page_nr_new = min(self.cursor_page_nr + 1, len(self.model) - 1)
         elif self.event.keyval == Gdk.KEY_Right:
-            self.cursor_page_nr_new = min(self.cursor_page_nr + 1, len(self.model) - 1)
+            if self.iconview.get_direction() == Gtk.TextDirection.LTR:
+                self.cursor_page_nr_new = min(self.cursor_page_nr + 1, len(self.model) - 1)
+            else:
+                self.cursor_page_nr_new = max(self.cursor_page_nr - 1, 0)
         elif self.event.keyval == Gdk.KEY_Home:
             self.cursor_page_nr_new = 0
         elif self.event.keyval == Gdk.KEY_End:
@@ -374,23 +380,24 @@ class IconviewDragSelect:
             if path:
                 ind = Gtk.TreePath.get_indices(path)[0]
                 break
+        add = 0.5 if self.iconview.get_direction() == Gtk.TextDirection.LTR else -0.5
         if pos == 'XY':
             location = ind
         elif pos == 'Right':
-            location = ind - 0.5
+            location = ind - add
         elif pos == 'Left':
-            location = ind + 0.5
+            location = ind + add
         elif pos == 'Below':
-            location = ind - self.iconview.get_item_column(path) - 0.5
+            location = ind - self.iconview.get_item_column(path) - add
         elif pos == 'Above':
-            location = ind + self.iconview.get_columns() - self.iconview.get_item_column(path) - 0.5
+            location = ind + self.iconview.get_columns() - self.iconview.get_item_column(path) - add
         elif (y > last_y + last.height) or (y > last_y and x > last_x + last.width):
-            location = len(self.model) - 0.5
+            location = len(self.model) - add
         elif y < 0:
-            location = -0.5
+            location = -add
         else:
             return None
-        return min(location, len(self.model) - 0.5)
+        return min(location, len(self.model) - add)
 
     def set_mouse_cursor(self, cursor_name):
         """Set the cursor type specified by cursor_name."""

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1825,7 +1825,10 @@ class PdfArranger(Gtk.Application):
             ref_to = Gtk.TreeRowReference.new(model, self.drag_path)
         else:
             ref_to = None
-        before = self.drag_pos == Gtk.IconViewDropPosition.DROP_LEFT
+        if self.iconview.get_direction() == Gtk.TextDirection.LTR:
+            before = self.drag_pos == Gtk.IconViewDropPosition.DROP_LEFT
+        else:
+            before = self.drag_pos == Gtk.IconViewDropPosition.DROP_RIGHT
         target = selection_data.get_target().name()
         if target == 'MODEL_ROW_INTERN':
             move = context.get_selected_action() & Gdk.DragAction.MOVE
@@ -1932,7 +1935,10 @@ class PdfArranger(Gtk.Application):
             return Gdk.EVENT_STOP
         elif not path or (path == model[-1].path and x_s < x):
             self.drag_path = model[-1].path
-            self.drag_pos = Gtk.IconViewDropPosition.DROP_RIGHT
+            if self.iconview.get_direction() == Gtk.TextDirection.LTR:
+                self.drag_pos = Gtk.IconViewDropPosition.DROP_RIGHT
+            else:
+                self.drag_pos = Gtk.IconViewDropPosition.DROP_LEFT
         else:
             iconview.stop_emission('drag_motion')
             return Gdk.EVENT_PROPAGATE
@@ -2165,16 +2171,11 @@ class PdfArranger(Gtk.Application):
         if target_id == self.TEXT_URI_LIST:
             pageadder = PageAdder(self)
             model = self.iconview.get_model()
-            ref_to = None
-            before = True
-            if len(model) > 0:
-                last_row = model[-1]
-                if self.drag_pos == Gtk.IconViewDropPosition.DROP_LEFT:
-                    ref_to = Gtk.TreeRowReference.new(model, self.drag_path)
-                elif self.drag_path != last_row.path:
-                    iter_next = model.iter_next(model.get_iter(self.drag_path))
-                    path_next = model.get_path(iter_next)
-                    ref_to = Gtk.TreeRowReference.new(model, path_next)
+            ref_to = Gtk.TreeRowReference.new(model, self.drag_path) if len(model) > 0 else None
+            if self.iconview.get_direction() == Gtk.TextDirection.LTR:
+                before = self.drag_pos == Gtk.IconViewDropPosition.DROP_LEFT
+            else:
+                before = self.drag_pos == Gtk.IconViewDropPosition.DROP_RIGHT
             pageadder.move(ref_to, before)
             for uri in selection_data.get_uris():
                 filename = get_file_path_from_uri(uri)


### PR DESCRIPTION
This fixes:
* Drag and drop of pages
* Dragging in a file
* Selecting pages by clicking and dragging mouse
* Navigating and selecting with keyboard arrows