### PR TITLE
Add missing release to metainfo

### DIFF
--- a/data/com.github.jeromerobert.pdfarranger.metainfo.xml
+++ b/data/com.github.jeromerobert.pdfarranger.metainfo.xml
@@ -176,6 +176,7 @@ See file COPYING or go to <http://www.gnu.org/licenses/> for full license detail
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2023-07-08" version="1.10.0"/>
     <release date="2022-11-27" version="1.9.2"/>
     <release date="2022-09-24" version="1.9.1"/>
     <release date="2022-09-17" version="1.9.0"/>


### PR DESCRIPTION
Flathub shows the wrong version without this data, but I guess this is not worth a bugfix release or anything. It would be nice to have it right in the coming releases though, do we have a release checklist somewhere?