### PR TITLE
Fix locale.format removed from Python 3.12

### DIFF
--- a/pdfarranger/pageutils.py
+++ b/pdfarranger/pageutils.py
@@ -69,7 +69,7 @@ class _LinkedSpinButton(Gtk.SpinButton):
 
     def __output(self, _user_data):
         """ output signal handler to remove unneeded 0 """
-        s = locale.format("%.8g", self.get_adjustment().get_value())
+        s = locale.format_string("%.8g", self.get_adjustment().get_value())
         self.get_buffer().set_text(s, len(s))
         return True
 


### PR DESCRIPTION
format_string is available since Python 3.5 (maybe earlier) and should be a drop in replacement

Closes #989 