### PR TITLE
Require equal pages in get_blank_doc()

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -79,7 +79,7 @@ def get_blank_doc(pageadder, pdfqueue, tmpdir, size, npages=1):
     need to be something else than 1.
     """
     for i, pdfdoc in enumerate(pdfqueue):
-        if size == pdfdoc.blank_size and npages <= pdfdoc.document.get_n_pages():
+        if size == pdfdoc.blank_size and npages == pdfdoc.document.get_n_pages():
             filename = pdfdoc.copyname
             nfile = i + 1
             return filename, nfile


### PR DESCRIPTION
This case does not work as expected:
1. Open a pdf with several pages
2. Select all, Merge pages, click ok
3. Undo
4. Delete all pages except first page
5. Select page and Merge pages, click ok

-> There are blank pages after the merged page

Issue introduced here 113ec64e7da1a45dc907376c701b29b772be19d8