### PR TITLE
Fix a "raise KeyError(key) from None" in pikepdf

### DIFF
--- a/pdfarranger/metadata.py
+++ b/pdfarranger/metadata.py
@@ -87,6 +87,9 @@ def _safeiter(elements):
             break
         except ValueError:
             traceback.print_exc()
+        except KeyError:
+            # Workaround for https://github.com/pdfarranger/pdfarranger/issues/1019
+            pass
 
 
 def merge_doc(metadata, input_docs):


### PR DESCRIPTION
* At pikepdf/models/metadata.py:706
* Close #1019