### PR TITLE
Show content loss warning on import

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -180,36 +180,6 @@ def _scale(doc, page, factor):
     new_page = doc.make_indirect(new_page)
     return new_page
 
-def check_content(parent, pdf_list):
-    """ Warn about fillable forms or outlines that are lost on export."""
-    warn = False
-    for pdf in [pikepdf.open(p.copyname, password=p.password) for p in pdf_list]:
-        if "/AcroForm" in pdf.Root.keys(): # fillable form
-            warn = True
-            break
-        if pdf.open_outline().root: # table of contents
-            warn = True
-            break
-    if warn:
-        d = Gtk.Dialog(_('Warning'),
-                       parent=parent,
-                       flags=Gtk.DialogFlags.MODAL,
-                       buttons=("_Cancel", Gtk.ResponseType.CANCEL,
-                                "_OK", Gtk.ResponseType.OK))
-        label = Gtk.Label(_('Forms and outlines are lost on saving.'))
-        d.vbox.pack_start(label, False, False, 6)
-        checkbutton = Gtk.CheckButton(_('Do not show this dialog again.'))
-        d.vbox.pack_start(checkbutton, False, False, 6)
-        buttonbox = d.get_action_area()
-        buttons = buttonbox.get_children()
-        d.set_focus(buttons[1])
-        d.show_all()
-        response = d.run()
-        enable_warnings = not checkbutton.get_active()
-        d.destroy()
-        return response, enable_warnings
-    return Gtk.ResponseType.OK, True
-
 
 def _update_angle(model_page, source_page, output_page):
     angle = model_page.angle

--- a/tests/test.py
+++ b/tests/test.py
@@ -78,6 +78,12 @@ def have_pikepdf3():
     ) >= packaging.version.Version("3")
 
 
+def have_pikepdf8():
+    return packaging.version.parse(
+        metadata.version("pikepdf")
+    ) >= packaging.version.Version("8.0")
+
+
 class XvfbManager:
     """Base class for running offscreen tests"""
 
@@ -355,6 +361,17 @@ class PdfArrangerTest(unittest.TestCase):
             time.sleep(0.1)
         registry.generateKeyboardEvent(code, None, KEY_RELEASE)
 
+    def _content_loss_warning(self):
+        """Handle the "content loss warning" dialog"""
+        self._wait_cond(lambda: len(self._find_by_role("alert")) > 0)
+        alert = self._find_by_role("alert")[-1]
+        self._wait_cond(lambda: len(self._find_by_role("check box", alert)) > 0)
+        check_box = self._find_by_role("check box", alert)[-1]
+        check_box.click()  # Don't show this dialog again
+        button = self._find_by_role("push button", alert)[-1]
+        button.click()
+        self._wait_cond(lambda: alert.dead)
+
     def _quit(self):
         self._app().child(roleName="layered pane").keyCombo("<ctrl>q")
 
@@ -389,6 +406,8 @@ class PdfArrangerTest(unittest.TestCase):
 class TestBatch1(PdfArrangerTest):
     def test_01_import_img(self):
         self._start(["data/screenshot.png"])
+        if not have_pikepdf8():
+            self._content_loss_warning()
 
     def test_02_properties(self):
         self._mainmenu("Edit Properties")
@@ -649,6 +668,8 @@ class TestBatch4(PdfArrangerTest):
     def test_05_import(self):
         filename = os.path.join(self.__class__.tmp, "scaled.pdf")
         filechooser = self._import_file(filename)
+        if have_pikepdf8():
+            self._content_loss_warning()
         self._wait_cond(lambda: filechooser.dead)
         self.assertEqual(len(self._icons()), 3)
         app = self._app()


### PR DESCRIPTION
This does also not check for what content is in the pdf, which will speed up adding of large pdfs when "content_loss_warning" is enabled.

What do you think about this? Also @m-holger 