### PR TITLE
Show content loss warning on start & and link to user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ interactive and intuitive graphical interface. It is a front end for
 [Sourceforge](http://sourceforge.net/projects/pdfshuffler)).
 It’s a humble attempt to make the project a bit more active.
 
+For more info see [User Manual](https://github.com/pdfarranger/pdfarranger/wiki/User-Manual).
+
 ![screenshot of PDF Arranger](https://github.com/pdfarranger/pdfarranger/raw/main/data/screenshot.png)
 
 ## Downloads
@@ -26,18 +28,6 @@ It’s a humble attempt to make the project a bit more active.
 ### Linux and BSD packages
 
 [![Linux packages](https://repology.org/badge/vertical-allrepos/pdfarranger.svg?columns=4&exclude_unsupported=1)](https://repology.org/project/pdfarranger/versions)
-
-## Customization of keyboard shortcuts
-
-You can change the default keyboard shortcuts. To do so, set `enable_custom` to `true` and edit the shortcuts in `config.ini` in the `[accelerators]` section.
-
-*   For Linux: `~/.config/pdfarranger/config.ini`
-*   For Windows installer version: `C:\Users\username\AppData\Roaming\pdfarranger\config.ini`
-*   For Windows portable version, the file is located in the same folder as pdfarranger.exe. Optionally, this file can be removed. The application will then use the same config file location as in the installer version.
-
-## Set custom language
-
-Language can be selected in the `Preferences` dialog. (PDF Arranger > 1.9.2)
 
 ## Install from source
 
@@ -113,7 +103,7 @@ For Windows see [Win32.md](Win32.md).
     *   pick a strong letter (e.g. in "Search and replace" rather pick `s`, `r` or `p` than `a`)
 
 *   If possible, test your translation to see it in context
-    (see [For developers](#for-developers) and [Set custom language](#Set-custom-language))
+    (see [For developers](#for-developers))
 
 *   Do not include `pdfarranger.pot` (or any `*.po` file which was just
     automatically regenerated) in your pull request. Submit only the translations

--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -32,7 +32,6 @@ import pathlib
 import shutil
 import tempfile
 import threading
-import pikepdf
 import packaging.version as version
 from typing import NamedTuple, Optional, Tuple, Union
 import gettext
@@ -646,12 +645,6 @@ class PageAdder:
             print(e.message, file=sys.stderr)
             self.app.error_message_dialog(e.message)
             return None
-
-        if self.app.config.content_loss_warning():
-            old = version.parse(pikepdf.__version__) < version.Version("8.0")
-            lpdf = len(self.app.pdfqueue)
-            if (old and lpdf == 0) or (not old and lpdf == 1):
-                self.app.content_loss_warning(old)
 
         self.app.pdfqueue.append(pdfdoc)
         return pdfdoc, len(self.app.pdfqueue), True

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -673,6 +673,9 @@ class PdfArranger(Gtk.Application):
         self.iv_drag_select = IconviewDragSelect(self)
         self.iv_pan_view = IconviewPanView(self)
 
+        if self.config.content_loss_warning():
+            self.content_loss_warning()
+
     def do_command_line(self, command_line):
         options = command_line.get_options_dict()
 
@@ -2716,19 +2719,23 @@ class PdfArranger(Gtk.Application):
             model.reorder(new_order)
         GObject.idle_add(self.render)
 
-    def content_loss_warning(self, old):
-        """Warn about that outlines might be lost on export."""
-        if old:
-            msg = _("Installed pikepdf is too old for preserving of outlines.")
-        else:
-            msg = _("Outlines can be preserved only for the first opened document.")
-        d = Gtk.MessageDialog(
-            type=Gtk.MessageType.INFO,
+    def content_loss_warning(self):
+        d = Gtk.Dialog(_("Note"),
             parent=self.window,
-            text=msg,
-            buttons=Gtk.ButtonsType.OK
+            flags=Gtk.DialogFlags.MODAL,
+            buttons=("_OK", Gtk.ResponseType.OK),
+            resizable=False
             )
-        cb = Gtk.CheckButton(_("Do not show this dialog again."), can_focus=False)
+        m1 = _("Note the limitations:")
+        m2 = _("Cropping/hiding does not remove any content from the PDF file, it only hides it.")
+        m3 = _("Outlines and links can be preserved only in certain cases.")
+        link = "https://github.com/pdfarranger/pdfarranger/wiki/User-Manual"
+        section = "#preserving-of-outlines-and-links"
+        markup = (m1 + "\n\n" + m2 + "\n\n" + m3 + " " + _("For more info see") +
+                  " " + '<a href="' + link + section + '">' + _("User Manual") + "</a>")
+        label = Gtk.Label(label=markup, use_markup=True, max_width_chars=50, wrap=True, margin=12)
+        cb = Gtk.CheckButton(_("Do not show this dialog again."), can_focus=False, margin=12)
+        d.vbox.pack_start(label, False, False, 6)
         d.vbox.pack_start(cb, False, False, 6)
         d.show_all()
         cb.set_can_focus(True)

--- a/tests/test.py
+++ b/tests/test.py
@@ -361,17 +361,6 @@ class PdfArrangerTest(unittest.TestCase):
             time.sleep(0.1)
         registry.generateKeyboardEvent(code, None, KEY_RELEASE)
 
-    def _content_loss_warning(self):
-        """Handle the "content loss warning" dialog"""
-        self._wait_cond(lambda: len(self._find_by_role("alert")) > 0)
-        alert = self._find_by_role("alert")[-1]
-        self._wait_cond(lambda: len(self._find_by_role("check box", alert)) > 0)
-        check_box = self._find_by_role("check box", alert)[-1]
-        check_box.click()  # Don't show this dialog again
-        button = self._find_by_role("push button", alert)[-1]
-        button.click()
-        self._wait_cond(lambda: alert.dead)
-
     def _quit(self):
         self._app().child(roleName="layered pane").keyCombo("<ctrl>q")
 
@@ -406,8 +395,15 @@ class PdfArrangerTest(unittest.TestCase):
 class TestBatch1(PdfArrangerTest):
     def test_01_import_img(self):
         self._start(["data/screenshot.png"])
-        if not have_pikepdf8():
-            self._content_loss_warning()
+        # Handle the "content loss warning" dialog
+        self._wait_cond(lambda: len(self._find_by_role("dialog")) > 0)
+        dialog = self._find_by_role("dialog")[-1]
+        self._wait_cond(lambda: len(self._find_by_role("check box", dialog)) > 0)
+        check_box = self._find_by_role("check box", dialog)[-1]
+        check_box.click()  # Don't show this dialog again
+        button = self._find_by_role("push button", dialog)[-1]
+        button.click()
+        self._wait_cond(lambda: dialog.dead)
 
     def test_02_properties(self):
         self._mainmenu("Edit Properties")
@@ -669,8 +665,6 @@ class TestBatch4(PdfArrangerTest):
     def test_05_import(self):
         filename = os.path.join(self.__class__.tmp, "scaled.pdf")
         filechooser = self._import_file(filename)
-        if have_pikepdf8():
-            self._content_loss_warning()
         self._wait_cond(lambda: filechooser.dead)
         self.assertEqual(len(self._icons()), 3)
         app = self._app()


### PR DESCRIPTION
1. Moved some user manual stuff to user manual on wiki.
2. Showing the "content loss warning" on second added document is actually too late, there are already limitations on the first document. So here is one idea how it could be done.

![image](https://github.com/pdfarranger/pdfarranger/assets/60842129/a613aac2-9027-4dac-88fa-ab1ea80a3bfb)
