### PR TITLE
Add standard paper sizes to "insert blank page" and "page size" dialogs

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -306,7 +306,7 @@ class BasePage:
 
 
 class Page(BasePage):
-    def __init__(self, nfile, npage, zoom, copyname, angle, scale, crop: Sides, hide: Sides, size_orig: Dims, basename, layerpages):
+    def __init__(self, nfile, npage, zoom, copyname, angle, scale, crop: Sides, hide: Sides, size_orig: Dims, description, layerpages):
         super().__init__(nfile, npage, copyname, angle, scale, Sides(*crop), size_orig)
         self.zoom = zoom
         self.hide = Sides(*hide)
@@ -315,19 +315,14 @@ class Page(BasePage):
         self.resample = -1
         self.preview = None
         """A low resolution thumbnail"""
-        #: The name of the original file
-        self.basename = basename
-        """The name of the original file"""
+        self.description = description
+        """The text under the thumbnail"""
         self.layerpages = list(layerpages)
 
     def __repr__(self):
         return (f"Page({self.nfile}, {self.npage}, {self.zoom}, '{self.copyname}', "
                 f"{self.angle}, {self.scale}, {self.crop}, {self.hide}, "
-                f"{self.size_orig}, '{self.basename}', {self.layerpages})")
-
-    def description(self):
-        shortname = os.path.splitext(self.basename)[0]
-        return "".join([shortname, "\n", _("page"), " ", str(self.npage)])
+                f"{self.size_orig}, '{self.description}', {self.layerpages})")
 
     def rotate(self, angle: int):
         rt = self.rotate_times(angle)
@@ -349,9 +344,9 @@ class Page(BasePage):
     def serialize(self):
         """Convert to string for copy/past operations."""
         lpdata = [lp.serialize() for lp in self.layerpages]
-        ts = [self.copyname, self.npage, self.basename, self.angle, self.scale]
+        ts = [self.copyname, self.npage, self.description, self.angle, self.scale]
         ts += list(self.crop) + list(self.hide) + list(lpdata)
-        return "\n".join([str(v) for v in ts])
+        return "///".join([str(v) for v in ts])
 
     def duplicate(self, incl_thumbnail=True):
         r = copy.copy(self)
@@ -417,7 +412,7 @@ class LayerPage(BasePage):
         """Convert to string for copy/past operations."""
         ts = [self.copyname, self.npage, self.angle, self.scale, self.laypos]
         ts += list(self.crop) + list(self.offset)
-        return "\n".join([str(v) for v in ts])
+        return "///".join([str(v) for v in ts])
 
     def duplicate(self):
         r = copy.copy(self)
@@ -533,21 +528,21 @@ class PDFDoc:
                 if not askpass:
                     raise e
 
-    def __init__(self, filename, basename, blank_size, stat, tmp_dir, parent):
+    def __init__(self, filename, description, blank_size, stat, tmp_dir, parent):
         self.render_lock = threading.Lock()
         self.filename = os.path.abspath(filename)
         self.stat = stat
-        if basename is None:  # When importing files
+        if description is None:  # When importing files
             self.basename = os.path.basename(filename)
         else:  # When copy-pasting
-            self.basename = basename
+            self.basename = description.split('\n')[0]
         self.blank_size = blank_size  # != None if page is blank
         self.password = ""
         filemime = mimetypes.guess_type(self.filename)[0]
         if not filemime:
             raise PDFDocError(_("Unknown file format"))
         if filemime == "application/pdf":
-            if self.filename.startswith(tmp_dir) and basename is None:
+            if self.filename.startswith(tmp_dir) and description is None:
                 # In the "Insert Blank Page" we don't need to copy self.filename
                 self.copyname = self.filename
                 self.basename = ""
@@ -613,7 +608,7 @@ class PageAdder:
         self.before = before
         self.treerowref = treerowref
 
-    def get_pdfdoc(self, filename: str, basename: Optional[str] = None, blank_size=None) -> Optional[Tuple[PDFDoc, int, bool]]:
+    def get_pdfdoc(self, filename: str, description: Optional[str] = None, blank_size=None) -> Optional[Tuple[PDFDoc, int, bool]]:
         """Get the pdfdoc object for the filename.
 
         pdfqueue is searched for the filename. If it is not found a pdfdoc is created
@@ -641,7 +636,7 @@ class PageAdder:
                 return it_pdfdoc, i + 1, False
 
         try:
-            pdfdoc = PDFDoc(filename, basename, blank_size, self.stat_cache[filename],
+            pdfdoc = PDFDoc(filename, description, blank_size, self.stat_cache[filename],
                             self.app.tmp_dir, self.app.window)
         except _UnknownPasswordException:
             return None
@@ -669,17 +664,17 @@ class PageAdder:
             layerpages.append(LayerPage(*ld))
         return layerpages
 
-    def addpages(self, filename, page=-1, basename=None, angle=0, scale=1.0, crop=Sides(0, 0, 0, 0), hide=Sides(0, 0, 0, 0), layerdata=None):
+    def addpages(self, filename, page=-1, description=None, angle=0, scale=1.0, crop=Sides(0, 0, 0, 0), hide=Sides(0, 0, 0, 0), layerdata=None):
         c = 'pdf' if page == -1 and os.path.splitext(filename)[1].lower() == '.pdf' else 'other'
         self.content.append(c)
         self.pdfqueue_used = len(self.app.pdfqueue) > 0
 
-        doc_data = self.get_pdfdoc(filename, basename)
+        doc_data = self.get_pdfdoc(filename, description)
         if doc_data is None:
             return
         pdfdoc, nfile, doc_added = doc_data
 
-        if (doc_added and pdfdoc.copyname != pdfdoc.filename and basename is None and not
+        if (doc_added and pdfdoc.copyname != pdfdoc.filename and description is None and not
                 (filename.startswith(self.app.tmp_dir) and filename.endswith(".png"))):
             self.app.import_directory = os.path.split(filename)[0]
             self.app.export_directory = self.app.import_directory
@@ -695,6 +690,11 @@ class PageAdder:
 
         for npage in range(n_start, n_end + 1):
             page = pdfdoc.document.get_page(npage - 1)
+            if description is None:
+                shortname = os.path.splitext(pdfdoc.basename)[0]
+                desc = "".join([shortname, "\n", _("page"), " ", str(npage)])
+            else:
+                desc = description
             self.pages.append(
                 Page(
                     nfile,
@@ -706,7 +706,7 @@ class PageAdder:
                     crop,
                     hide,
                     Dims(*page.get_size()),
-                    pdfdoc.basename,
+                    desc,
                     layerpages,
                 )
             )
@@ -723,7 +723,7 @@ class PageAdder:
             self.pages.reverse()
         with self.app.render_lock():
             for p in self.pages:
-                m = [p, p.description()]
+                m = [p, p.description]
                 if self.treerowref:
                     iter_to = self.app.model.get_iter(self.treerowref.get_path())
                     if self.before:

--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -286,6 +286,10 @@ class BasePage:
         """Return the page size in PDF points."""
         return self.size.scaled(self.scale).cropped(self.crop)
 
+    def size_in_mm(self) -> Dims:
+        """Return the page size in mm."""
+        return self.size_in_points() * 25.4 / 72
+
     def width_in_pixel(self):
         return self.size_in_pixel().width
 

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -65,7 +65,7 @@ def get_blank_doc(pageadder, pdfqueue, tmpdir, size, npages=1):
             nfile = i + 1
             return filename, nfile
     filename = _create_blank_page(tmpdir, size, npages)
-    doc_data = pageadder.get_pdfdoc(filename, basename=None, blank_size=size)
+    doc_data = pageadder.get_pdfdoc(filename, description=None, blank_size=size)
     if doc_data is None:
         return None, None
     nfile = doc_data[1]

--- a/pdfarranger/pageutils.py
+++ b/pdfarranger/pageutils.py
@@ -184,6 +184,15 @@ class PaperSizeWidget(Gtk.Grid):
         self.ratios = [size[0] / size[1], size[1] / size[0]]
         self.set_entry_size(size)
         self.select_paper_and_orientation()
+        self.update_entry_limits()
+        self.ratio_cb.connect('clicked', self.update_entry_limits)
+
+    def update_entry_limits(self, _widget=None):
+        r = self.ratios if self.ratio_cb.get_active() else [1, 1]
+        wrange = max(25.4, 25.4 * r[0]), min(5080, 5080 * r[0])
+        hrange = max(25.4, 25.4 * r[1]), min(5080, 5080 * r[1])
+        self.width_entry.set_range(*wrange)
+        self.height_entry.set_range(*hrange)
 
     def width_changed(self, _widget):
         if self.ratio_cb.get_active():
@@ -199,8 +208,11 @@ class PaperSizeWidget(Gtk.Grid):
 
     def orientation_clicked(self, _widget):
         size = self.get_value(Gtk.Unit.MM)
+        self.width_entry.set_range(25.4, 5080)
+        self.height_entry.set_range(25.4, 5080)
         self.set_entry_size(sorted(size, reverse=self.land.get_active()))
         self.ratios.sort(reverse=self.land.get_active())
+        self.update_entry_limits()
 
     def paper_size_changed(self, combo):
         paper = self.papers[combo.get_active()]
@@ -208,6 +220,7 @@ class PaperSizeWidget(Gtk.Grid):
         self.set_entry_size(sorted(size, reverse=self.land.get_active()))
         if round(size[0] / size[1], 5) not in [round(r, 5) for r in self.ratios]:
             self.ratio_cb.set_active(False)
+            self.update_entry_limits()
 
     def select_paper_and_orientation(self):
         size = self.get_value(Gtk.Unit.MM)

--- a/pdfarranger/pageutils.py
+++ b/pdfarranger/pageutils.py
@@ -343,6 +343,13 @@ class ScaleDialog(BaseDialog):
         self.set_resizable(False)
         page = model.get_value(model.get_iter(selection[-1]), 0)
         paper_widget = PaperSizeWidget(page.size_in_mm(), margin=1)
+        paper_widget.attach(Gtk.Label(_("Fit mode"), halign=Gtk.Align.START), 1, 5, 1, 1)
+        self.combo = Gtk.ComboBoxText()
+        self.combo.append('SCALE', _("Scale"))
+        self.combo.append('SCALE-ADD-MARG', _("Scale & Add margins"))
+        self.combo.append('CROP-ADD-MARG', _("Crop & Add margins"))
+        self.combo.set_active(0)
+        paper_widget.attach(self.combo, 2, 5, 1, 1)
         rel_widget = _RelativeScalingWidget(page.scale)
         self.scale_stack = _RadioStackSwitcher(margin=15)
         self.scale_stack.add_named(paper_widget, "Fit", _("Fit to paper"))
@@ -358,7 +365,9 @@ class ScaleDialog(BaseDialog):
         result = self.run()
         val = None
         if result == Gtk.ResponseType.OK:
-            val = self.scale_stack.selected_child.get_value()
+            s = self.scale_stack
+            mode = 'SCALE' if s.selected_name == 'Relative' else self.combo.get_active_id()
+            val = s.selected_child.get_value(), mode
         self.destroy()
         return val
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -897,7 +897,7 @@ class PdfArranger(Gtk.Application):
                 self.iconview.select_path(path)
                 self.iconview.unselect_path(path)
         ac = self.iconview.get_accessible().ref_accessible_child(path.get_indices()[0])
-        ac.set_description(page.description())
+        ac.set_description(page.description)
 
     def get_visible_range2(self):
         """Get range of items visible in window.
@@ -1554,7 +1554,7 @@ class PdfArranger(Gtk.Application):
     def paste_as_layer(self, data, destination, laypos, offset_xy=None):
         page_stack = []
         pageadder = PageAdder(self)
-        for filename, npage, _basename, angle, scale, crop, hide, layerdata in data:
+        for filename, npage, _description, angle, scale, crop, hide, layerdata in data:
             d = [[filename, npage, angle, scale, laypos, crop, Sides()]] + layerdata
             lps = pageadder.get_layerpages(d)
             self.apply_hide_margins_on_layerpages(lps, hide)
@@ -1687,13 +1687,13 @@ class PdfArranger(Gtk.Application):
         """Deserialize data from copy & paste or drag & drop operation."""
         d = []
         while data:
-            tmp = data.pop(0).split('\n')
+            tmp = data.pop(0).split('///')
             filename = tmp[0]
             npage = int(tmp[1])
             if len(tmp) < 3:  # Only when paste files interleaved
                 d.append((filename, npage))
             else:
-                basename = tmp[2]
+                description = tmp[2]
                 angle = int(tmp[3])
                 scale = float(tmp[4])
                 crop = [float(side) for side in tmp[5:9]]
@@ -1710,7 +1710,7 @@ class PdfArranger(Gtk.Application):
                     loffset = [float(offs) for offs in tmp[i + 9:i + 13]]
                     layerdata.append([lfilename, lnpage, langle, lscale, laypos, lcrop, loffset])
                     i += 13
-                d.append((filename, npage, basename, angle, scale, crop, hide, layerdata))
+                d.append((filename, npage, description, angle, scale, crop, hide, layerdata))
         return d
 
     def set_paste_location(self, pastemode):
@@ -1942,9 +1942,9 @@ class PdfArranger(Gtk.Application):
                     iterator = model.get_iter(ref_from.get_path())
                     page = model.get_value(iterator, 0).duplicate()
                     if before:
-                        it = model.insert_before(iter_to, [page, page.description()])
+                        it = model.insert_before(iter_to, [page, page.description])
                     else:
-                        it = model.insert_after(iter_to, [page, page.description()])
+                        it = model.insert_after(iter_to, [page, page.description])
                     path = model.get_path(it)
                     iconview.select_path(path)
                 if move:
@@ -2483,7 +2483,7 @@ class PdfArranger(Gtk.Application):
                 newpages = page.split(leftcrops, topcrops)
                 for p in newpages:
                     p.resample = -1
-                    model.insert_after(iterator, [p, p.description()])
+                    model.insert_after(iterator, [p, p.description])
                 model.set_value(iterator, 0, page)
         self.update_iconview_geometry()
         self.iv_selection_changed_event()
@@ -2758,7 +2758,7 @@ class PdfArranger(Gtk.Application):
             for ref in ref_list:
                 iterator = model.get_iter(ref.get_path())
                 page = model.get_value(iterator, 0).duplicate()
-                model.insert_after(iterator, [page, page.description()])
+                model.insert_after(iterator, [page, page.description])
         self.iv_selection_changed_event()
         GObject.idle_add(self.render)
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -461,12 +461,12 @@ class PdfArranger(Gtk.Application):
                                      self.window.lookup_action('redo'))
 
     def insert_blank_page(self, _action, _option, _unknown):
-        size = (21 / 2.54 * 72, 29.7 / 2.54 * 72) # A4 by default
+        size = None
         selection = self.iconview.get_selected_items()
         selection.sort()
         model = self.iconview.get_model()
         if len(selection) > 0:
-            size = model[selection[-1]][0].size_in_points()
+            size = model[selection[-1]][0].size_in_mm()
         page_size = pageutils.BlankPageDialog(size, self.window).run_get()
         if page_size is not None:
             adder = PageAdder(self)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1579,7 +1579,7 @@ class PdfArranger(Gtk.Application):
             dpage = self.model[row][0]
             layerpage_stack = page_stack[num % len(page_stack)]
 
-            # Add the "main" pasted page
+            # The "main" pasted page
             lp0 = layerpage_stack[0].duplicate()
             dwidth, dheight = dpage.size[0] * dpage.scale, dpage.size[1] * dpage.scale
             scalex = (dpage.width_in_points() - lp0.width_in_points()) / dwidth
@@ -1590,7 +1590,9 @@ class PdfArranger(Gtk.Application):
                                right=1 - left - lp0.width_in_points() / dwidth,
                                top=top,
                                bottom=1 - top - lp0.height_in_points() / dheight)
-            dpage.layerpages.append(lp0)
+            if self.pdfqueue[lp0.nfile - 1].blank_size is None:
+                # Add "main" pasted page if it is not blank
+                dpage.layerpages.append(lp0)
 
             # Add layers from the pasted page
             nfirst = len(dpage.layerpages) - 1

--- a/pdfarranger/undo.py
+++ b/pdfarranger/undo.py
@@ -86,7 +86,7 @@ class Manager(object):
                 # Do not reset the zoom level
                 page.zoom = self.app.zoom_scale
                 page.resample = -1
-                self.model.append([page, page.description()])
+                self.model.append([page, page.description])
         self.app.update_iconview_geometry()
         self.app.update_max_zoom_level()
         self.app.retitle()

--- a/tests/test.py
+++ b/tests/test.py
@@ -341,6 +341,8 @@ class PdfArrangerTest(unittest.TestCase):
         app = self._app()
         app.keyCombo("S")
         dialog = app.child(roleName="dialog")
+        relative = self._find_by_role("radio button", dialog)[1]
+        relative.click()
         from dogtail import rawinput
         rawinput.keyCombo("Tab")
         rawinput.typeText(str(scale))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,8 +109,8 @@ class PageTest(PTest):
     def test03(self):
         """Test serialize"""
         self.assertEqual(self._page1().serialize(),
-                         'copy\n2\nbase\n0\n2\n0.1\n0.2\n0.3\n0.4\n0.11\n0.21\n0.31\n0.41\n'
-                         'lcopy\n4\n90\n2\nOVERLAY\n0.11\n0.21\n0.31\n0.41\n0.12\n0.22\n0.32\n0.42')
+                         'copy///2///base///0///2///0.1///0.2///0.3///0.4///0.11///0.21///0.31///0.41///'
+                         'lcopy///4///90///2///OVERLAY///0.11///0.21///0.31///0.41///0.12///0.22///0.32///0.42')
 
     def test04(self):
         """Test width | height | size_in_pixel"""
@@ -160,7 +160,7 @@ class LayerPageTest(PTest):
     def test03(self):
         """Test serialize"""
         self.assertEqual(self._lpage1().serialize(),
-                         'lcopy\n4\n90\n2\nOVERLAY\n0.11\n0.21\n0.31\n0.41\n0.12\n0.22\n0.32\n0.42')
+                         'lcopy///4///90///2///OVERLAY///0.11///0.21///0.31///0.41///0.12///0.22///0.32///0.42')
 
 
 def load_tests(loader, tests, ignore):


### PR DESCRIPTION
Old - New
![old -new](https://github.com/pdfarranger/pdfarranger/assets/60842129/35946b96-6922-4b14-a730-57b95b635164)
Scaling to a paper size is what I usually want to do. The old (fit to) "width" and "height" can be achieved by setting for example width to desired value and height to a large value.

As the translation files was updated, this can wait to next release if you like to.