### PR TITLE
Do not show full path name in headerbar (fixes #1085)

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -533,9 +533,11 @@ class PdfArranger(Gtk.Application):
             filter_list.append(f_img)
         return filter_list
 
-    def set_title(self, title):
+    def set_title(self, title, subtitle = None):
         if Handy:
             self.uiXML.get_object('header_bar').set_title(title)
+            if subtitle is not None:
+                self.uiXML.get_object('header_bar').set_subtitle(subtitle)
         else:
             self.window.set_title(title)
 
@@ -822,8 +824,9 @@ class PdfArranger(Gtk.Application):
         GObject.idle_add(self.retitle)
 
     def retitle(self):
+        subtitle = None
         if self.save_file:
-            title = self.save_file
+            subtitle, title = os.path.split(self.save_file)
         else:
             title = _('untitled')
         if self.is_unsaved:
@@ -835,7 +838,7 @@ class PdfArranger(Gtk.Application):
             title += ' [' + ', '.join(sorted(all_files)) + ']'
 
         title += ' – ' + APPNAME
-        self.set_title(title)
+        self.set_title(title, subtitle)
         return False
 
     def update_thumbnail(self, _obj, ref, thumbnail, zoom, scale, is_preview):

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -536,8 +536,7 @@ class PdfArranger(Gtk.Application):
     def set_title(self, title, subtitle = None):
         if Handy:
             self.uiXML.get_object('header_bar').set_title(title)
-            if subtitle is not None:
-                self.uiXML.get_object('header_bar').set_subtitle(subtitle)
+            self.uiXML.get_object('header_bar').set_subtitle(subtitle)
         else:
             self.window.set_title(title)
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -534,11 +534,8 @@ class PdfArranger(Gtk.Application):
         return filter_list
 
     def set_title(self, title, subtitle = None):
-        if Handy:
-            self.uiXML.get_object('header_bar').set_title(title)
-            self.uiXML.get_object('header_bar').set_subtitle(subtitle)
-        else:
-            self.window.set_title(title)
+        self.uiXML.get_object('header_bar').set_title(title)
+        self.uiXML.get_object('header_bar').set_subtitle(subtitle)
 
     def do_activate(self):
         """ https://lazka.github.io/pgi-docs/Gio-2.0/classes/Application.html#Gio.Application.do_activate """


### PR DESCRIPTION
see #1085 

It looks like this for me now:
![image](https://github.com/pdfarranger/pdfarranger/assets/39754510/998ca9b2-0647-4d05-a728-3b0db016fef4)
Please let me know if I've missed anything!