### PR TITLE
Fix booklet for pikepdf 9

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -544,7 +544,7 @@ def generate_booklet(pdfqueue, tmp_dir, pages):
                 Contents=pikepdf.Stream(file, content_txt.encode())
             )
 
-        file.pages.append(newpage)
+        file.pages.append(pikepdf.Page(newpage))
     for __ in range(to_remove):
         del file.pages[0]
     file.save(filename)


### PR DESCRIPTION
Tested with pikepdf 7.0.0, 8.0.0, 9.0.0
Fixes: https://github.com/pdfarranger/pdfarranger/issues/1094

We probably should run the whole testsuite against pikepdf 9.