### PR TITLE
Replace deprecated widget HBox with Box

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -450,7 +450,7 @@ class PasswordDialog(Gtk.Dialog):
         label.set_line_wrap(True)
         label.set_size_request(0, -1)
         self.vbox.pack_start(label, False, False, 12)
-        box = Gtk.HBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.entry = Gtk.Entry()
         self.entry.set_visibility(False)
         self.entry.set_activates_default(True)

--- a/pdfarranger/splitter.py
+++ b/pdfarranger/splitter.py
@@ -49,7 +49,7 @@ class Dialog(Gtk.Dialog):
         self.hcheck = Gtk.CheckButton()
         self.checkbuttons = {'vertical' : self.vcheck, 'horizontal' : self.hcheck}
 
-        hbox = Gtk.HBox()
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.vbox.pack_start(hbox, True, True, 0)
         for direction in ['vertical', 'horizontal']:
             frame = self._build_frame(direction)


### PR DESCRIPTION
This widget is deprecated since GTK 3.2, and has been removed in GTK 4.

I am planning on porting pdfarranger to this version of GTK, in order to benefit from the newer widgets such as Gtk.GridView, or the many Adwaita widgets.  I am thinking about making libadwaita mandatory, instead of the current libhandy being optional, so that it would work well also on my phone (the PinePhone).  Is this something you would welcome, or would want to discuss before I start that?