### PR TITLE
Simplify statusbar properties

### DIFF
--- a/data/pdfarranger.ui
+++ b/data/pdfarranger.ui
@@ -282,49 +282,20 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
           </packing>
         </child>
         <child>
-          <!-- n-columns=2 n-rows=1 -->
-          <object class="GtkGrid">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="row_spacing">10</property>
             <child>
               <object class="GtkStatusbar" id="statusbar">
                 <property name="visible">True</property>
-                <property name="margin_start">4</property>
-                <property name="margin_end">4</property>
-                <property name="margin_top">4</property>
-                <property name="margin_bottom">4</property>
-                <property name="hexpand">True</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">1</property>
+                <property name="hexpand">1</property>
               </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkStatusbar" id="statusbar2">
                 <property name="visible">True</property>
-                <property name="halign">end</property>
-                <property name="margin_start">4</property>
-                <property name="margin_end">4</property>
-                <property name="margin_top">4</property>
-                <property name="margin_bottom">4</property>
-                <property name="hexpand">True</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">1</property>
               </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/tests/test.py
+++ b/tests/test.py
@@ -216,7 +216,7 @@ class PdfArrangerTest(unittest.TestCase):
 
     def _is_saving(self):
         allstatusbar = self._find_by_role("status bar")
-        statusbar = allstatusbar[0]
+        statusbar = allstatusbar[-1]
         return statusbar.name.startswith("Saving")
 
     def _wait_saving(self):
@@ -228,8 +228,8 @@ class PdfArrangerTest(unittest.TestCase):
     def _status_text(self):
         self._app()
         allstatusbar = self._find_by_role("status bar")
-        # If we have multiple status bar, consider the last one as the one who display the selection
-        statusbar = allstatusbar[-1]
+        # If we have multiple status bar, consider the first one as the one who display the selection
+        statusbar = allstatusbar[0]
         return statusbar.name
 
     def _assert_selected(self, selection):


### PR DESCRIPTION
Very little of these properties make sense, we can replace the GtkGrid with a GtkBox and remove almost all of them.