### PR TITLE
Compatibility switch for saving document-level information

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -15,6 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
+import packaging.version as version
 import platform
 import ctypes
 
@@ -1152,10 +1153,10 @@ class PdfArranger(Gtk.Application):
         for f in filter_list[1:]:
             chooser.add_filter(f)
         primary_input_cb = Gtk.CheckButton(label=_("Keep document-level information from first page's file"))
-        if exportmode == 'ALL_TO_SINGLE':
-            primary_input_cb.set_active(True)
-        else:
+        if version.parse(pikepdf.__version__) < version.Version("8.0"):
             primary_input_cb.set_sensitive(False)
+        else:
+            primary_input_cb.set_active(exportmode == 'ALL_TO_SINGLE')
         chooser.set_extra_widget(primary_input_cb)
 
         response = chooser.run()


### PR DESCRIPTION
Let user decide whether document-level information, such as outlines, tags, encryption passwords, etc., shall be taken from the primary input file and be preserved in the output file. This became the default behavior with PDF Arranger 1.11 using pikepdf version 8 or newer, which uses QPDF jobs. Prior to that, the output was always built starting with a new, empty pdf document and thus all the document-level information from the input file was discarded in the output. This old behavior can now be enforced by deactivating the check button
"Keep document-level information from first page's file" in the save file chooser dialog. If this option is deactivated, the "--empty" qpdf option is used inplace of the primary input file. As a side effect, this for instance removes passwords when saving password-protected input files.

![grafik](https://github.com/user-attachments/assets/e7a8a6ed-6b11-4320-93ce-d5685aa92794)


Further, if the check button is kept activated (default), the pdf file of the first page to be saved is used as the primary input file. Previously the first opened file was used, which lead to unexpected/surprising behavior if all pages of this file are removed before saving or if other files' pages were moved to the beginning of the resulting document.

Closes #1144 