### PR TITLE
Add more explicit deps and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,28 @@ In addition, *PDF Arranger* supports image file import if [img2pdf](https://gitl
 
 ## For developers
 
+### Using setuptools
+
 ```
 git clone https://github.com/pdfarranger/pdfarranger.git
 cd pdfarranger
 ./setup.py build
 python3 -m pdfarranger
 ```
+
+### Using uv
+
+[uv](https://docs.astral.sh/uv/) is a modern alternative to setuptools. You can setup a development environment like this:
+
+```
+git clone https://github.com/pdfarranger/pdfarranger.git
+cd pdfarranger
+uv venv
+uv pip sync setup.py
+uv run python3 -m pdfarranger
+```
+
+### On Windows
 
 For Windows see [Win32.md](Win32.md).
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     entry_points={
         'console_scripts': ['pdfarranger=pdfarranger.pdfarranger:main']
     },
-    install_requires=['pikepdf>=6','python-dateutil>=2.4.0', 'packaging'],
+    install_requires=['pikepdf>=6','python-dateutil>=2.4.0', 'packaging', 'pillow>=11', 'lxml>=5.3', 'pygobject>=3.50', 'six>=1.16', 'pycairo>=1.27'],
     extras_require={
         'image': ['img2pdf>=0.3.4'],
     },


### PR DESCRIPTION
These are the versions i tested with. I have no idea if you want more relaxed requirements, but i was confused that i can not run pdfarranger because missing dependencies so i thought it's a good idea to declare them.

Also i added instructions to run uv because it's so much faster than setup tools starting the venv from scratch takes <1s.