### PR TITLE
Add switch to save into empty file

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -24,7 +24,6 @@ import tempfile
 import io
 import gi
 import locale
-import packaging.version as version
 from typing import Any, Dict, List
 
 from . import metadata
@@ -244,7 +243,7 @@ def warn_dialog(func):
             self.buffer += str(message) + '\n'
 
     def wrapper(*args, **kwargs):
-        export_msg = args[-1]
+        export_msg = kwargs["export_msg"]
         backup_showwarning = warnings.showwarning
         warnings.showwarning = ShowWarning()
         try:
@@ -489,11 +488,11 @@ def export_doc_job(pdf_input: List[pikepdf.Pdf], files: List[List[str]], pages: 
         job.write_pdf(pdf_output)
 
 
-def export(files, pages, mdata, files_out, quit_flag, _export_msg, test_mode=False):
+def export(files, pages, mdata, files_out, quit_flag, config, test_mode=False, **kwargs):
     pdf_input = [
         pikepdf.open(copyname, password=password) for copyname, password in files
     ]
-    if version.parse(pikepdf.__version__) < version.Version("8.0"):
+    if config.start_with_empty():
         export_doc(pdf_input, pages, mdata, files_out, quit_flag, test_mode)
     else:
         export_doc_job(pdf_input, files, pages, mdata, files_out, quit_flag, test_mode)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1301,8 +1301,9 @@ class PdfArranger(Gtk.Application):
 
         files = [(pdf.copyname, pdf.password) for pdf in self.pdfqueue]
         export_msg = multiprocessing.Queue()
-        a = files, pages, self.metadata, files_out, self.quit_flag, export_msg
-        self.export_process = multiprocessing.Process(target=exporter.export_process, args=a)
+        args = files, pages, self.metadata, files_out, self.quit_flag, self.config
+        kwargs = dict(export_msg=export_msg)
+        self.export_process = multiprocessing.Process(target=exporter.export_process, args=args, kwargs=kwargs)
         self.export_process.start()
         GObject.timeout_add(300, self.export_finished, exportmode, export_msg)
         self.set_export_state(True)

--- a/tests/exporter/test19_out.pdf
+++ b/tests/exporter/test19_out.pdf
@@ -1,0 +1,945 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 4
+  /Kids [
+    3 0 R
+    4 0 R
+    5 0 R
+    6 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 70 0
+3 0 obj
+<<
+  /Annots 7 0 R
+  /Contents 8 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F2 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 71 0
+4 0 obj
+<<
+  /Annots 11 0 R
+  /Contents 12 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F2 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 72 0
+5 0 obj
+<<
+  /Annots 14 0 R
+  /Contents 15 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F2 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+%% Original object ID: 73 0
+6 0 obj
+<<
+  /Annots 17 0 R
+  /Contents 18 0 R
+  /Group <<
+    /CS /DeviceRGB
+    /I true
+    /S /Transparency
+  >>
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F2 10 0 R
+    >>
+    /ProcSet [
+      /PDF
+      /Text
+    ]
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Original object ID: 16 0
+7 0 obj
+[
+  20 0 R
+  21 0 R
+  22 0 R
+  23 0 R
+]
+endobj
+
+%% Contents for page 1
+%% Original object ID: 11 0
+8 0 obj
+<<
+  /Length 9 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 1)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+
+endstream
+endobj
+
+%QDF: ignore_newline
+9 0 obj
+314
+endobj
+
+%% Original object ID: 15 0
+10 0 obj
+<<
+  /BaseFont /Courier
+  /Subtype /TrueType
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 31 0
+11 0 obj
+[
+  24 0 R
+  25 0 R
+  26 0 R
+  27 0 R
+]
+endobj
+
+%% Contents for page 2
+%% Original object ID: 29 0
+12 0 obj
+<<
+  /Length 13 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 2)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+
+endstream
+endobj
+
+%QDF: ignore_newline
+13 0 obj
+314
+endobj
+
+%% Original object ID: 46 0
+14 0 obj
+[
+  28 0 R
+  29 0 R
+  30 0 R
+  31 0 R
+]
+endobj
+
+%% Contents for page 3
+%% Original object ID: 44 0
+15 0 obj
+<<
+  /Length 16 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 3)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+
+endstream
+endobj
+
+%QDF: ignore_newline
+16 0 obj
+314
+endobj
+
+%% Original object ID: 61 0
+17 0 obj
+[
+  32 0 R
+  33 0 R
+  34 0 R
+  35 0 R
+]
+endobj
+
+%% Contents for page 4
+%% Original object ID: 59 0
+18 0 obj
+<<
+  /Length 19 0 R
+>>
+stream
+0.1 w
+
+q 0 0 0 rg
+BT
+55 750 Td /F2 18 Tf (Page 4)  Tj
+ET
+Q
+
+q 0 0 0.5019607843 rg
+BT
+55 700 Td /F2 12 Tf (Page 1) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 650 Td /F2 12 Tf (Page 2) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 600 Td /F2 12 Tf (Page 3) Tj
+ET
+Q 
+
+q 0 0 0.5019607843 rg
+BT
+55 550 Td /F2 12 Tf (Page 4) Tj
+ET
+Q
+
+endstream
+endobj
+
+%QDF: ignore_newline
+19 0 obj
+314
+endobj
+
+%% Original object ID: 17 0
+20 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    36 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 19 0
+21 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    37 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 21 0
+22 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    38 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 23 0
+23 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    39 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 32 0
+24 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    40 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 34 0
+25 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    41 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 36 0
+26 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    42 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 38 0
+27 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    43 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 47 0
+28 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    44 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 49 0
+29 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    45 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 51 0
+30 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    46 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 53 0
+31 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    47 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 62 0
+32 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    48 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    695
+    100
+    708
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 64 0
+33 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    49 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    645
+    100
+    658
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 66 0
+34 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    50 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    595
+    100
+    608
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 68 0
+35 0 obj
+<<
+  /Border [
+    0
+    0
+    0
+  ]
+  /Dest [
+    51 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Rect [
+    54
+    545
+    100
+    558
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+%% Original object ID: 18 0
+36 0 obj
+null
+endobj
+
+%% Original object ID: 20 0
+37 0 obj
+null
+endobj
+
+%% Original object ID: 22 0
+38 0 obj
+null
+endobj
+
+%% Original object ID: 24 0
+39 0 obj
+null
+endobj
+
+%% Original object ID: 33 0
+40 0 obj
+null
+endobj
+
+%% Original object ID: 35 0
+41 0 obj
+null
+endobj
+
+%% Original object ID: 37 0
+42 0 obj
+null
+endobj
+
+%% Original object ID: 39 0
+43 0 obj
+null
+endobj
+
+%% Original object ID: 48 0
+44 0 obj
+null
+endobj
+
+%% Original object ID: 50 0
+45 0 obj
+null
+endobj
+
+%% Original object ID: 52 0
+46 0 obj
+null
+endobj
+
+%% Original object ID: 54 0
+47 0 obj
+null
+endobj
+
+%% Original object ID: 63 0
+48 0 obj
+null
+endobj
+
+%% Original object ID: 65 0
+49 0 obj
+null
+endobj
+
+%% Original object ID: 67 0
+50 0 obj
+null
+endobj
+
+%% Original object ID: 69 0
+51 0 obj
+null
+endobj
+
+xref
+0 52
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000273 00000 n 
+0000000614 00000 n 
+0000000957 00000 n 
+0000001300 00000 n 
+0000001633 00000 n 
+0000001740 00000 n 
+0000002131 00000 n 
+0000002179 00000 n 
+0000002286 00000 n 
+0000002394 00000 n 
+0000002787 00000 n 
+0000002836 00000 n 
+0000002944 00000 n 
+0000003337 00000 n 
+0000003386 00000 n 
+0000003494 00000 n 
+0000003887 00000 n 
+0000003936 00000 n 
+0000004159 00000 n 
+0000004382 00000 n 
+0000004605 00000 n 
+0000004828 00000 n 
+0000005051 00000 n 
+0000005274 00000 n 
+0000005497 00000 n 
+0000005720 00000 n 
+0000005943 00000 n 
+0000006166 00000 n 
+0000006389 00000 n 
+0000006612 00000 n 
+0000006835 00000 n 
+0000007058 00000 n 
+0000007281 00000 n 
+0000007504 00000 n 
+0000007554 00000 n 
+0000007604 00000 n 
+0000007654 00000 n 
+0000007704 00000 n 
+0000007754 00000 n 
+0000007804 00000 n 
+0000007854 00000 n 
+0000007904 00000 n 
+0000007954 00000 n 
+0000008004 00000 n 
+0000008054 00000 n 
+0000008104 00000 n 
+0000008154 00000 n 
+0000008204 00000 n 
+0000008254 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 52
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+8276
+%%EOF

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -3,6 +3,7 @@ import os
 import packaging.version as version
 from typing import Any, List, Tuple
 import unittest
+from unittest.mock import Mock
 
 import pikepdf
 
@@ -89,26 +90,29 @@ class ExporterTest(unittest.TestCase):
 
         return True, ''
 
-    def case(self, test, files, *pages):
+    def case(self, test, files, *pages, start_with_empty=False):
         """Run a single test case."""
-        if version.parse(pikepdf.__version__) < version.Version('8.0.0'):
+        if version.parse(pikepdf.__version__) < version.Version('8.0.0') or start_with_empty:
             expected_file = file(f'test{test}_out')
+            start_with_empty = True
         else:
             expected_file = file(f'test{test}_8_out')
             if not os.path.exists(expected_file):
                 expected_file = file(f'test{test}_out')
 
-        export(files, pages, {}, [file('out')], None, None, True)
+        mock_config = Mock()
+        mock_config.start_with_empty.return_value = start_with_empty
+        export(files, pages, {}, [file('out')], None, mock_config, True)
         self.assertTrue(*self.compare_files(file('out'), expected_file))
 
     def basic(self, test, *pages):
         """Test with basic.pdf as single input file."""
         self.case(test, [(file('basic'), '')], *pages)
 
-    def outlines(self, test, *pages, ignore_8=None):
+    def outlines(self, test, *pages, ignore_8=None, start_with_empty=False):
         """Test with outlines.pdf as single input file."""
         if version.parse(pikepdf.__version__) >= version.Version('8.0.0'):
-            self.case(test, [(file('outlines'), '')], *pages)
+            self.case(test, [(file('outlines'), '')], *pages, start_with_empty=start_with_empty)
 
     def test01(self):
         """No transformations"""
@@ -198,6 +202,10 @@ class ExporterTest(unittest.TestCase):
     def test19(self):
         """Copy file with outlines"""
         self.outlines(19, Page(1), Page(2), Page(3), Page(4))
+
+    def test19a(self):
+        """Copy file and discard outlines for pikepdf 8 """
+        self.outlines(19, Page(1), Page(2), Page(3), Page(4), start_with_empty=True)
 
     def test20(self):
         """Reorder pages in file with outlines"""

--- a/tests/test_metadata1.pdf
+++ b/tests/test_metadata1.pdf
@@ -1,0 +1,46 @@
+%PDF-1.3
+%¿÷¢þ
+1 0 obj
+<< /Metadata 3 0 R /Pages 4 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Author (First) /Custom (info dict entry) /Title (Title1) >>
+endobj
+3 0 obj
+<< /Subtype /XML /Type /Metadata /Length 403 >>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="pikepdf">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <rdf:Description rdf:about=""><dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/"><rdf:Seq><rdf:li>First</rdf:li><rdf:li>Second</rdf:li></rdf:Seq></dc:creator></rdf:Description></rdf:RDF>
+</x:xmpmeta>
+
+<?xpacket end="w"?>
+
+endstream
+endobj
+4 0 obj
+<< /Count 1 /Kids [ 5 0 R ] /Type /Pages >>
+endobj
+5 0 obj
+<< /Contents 6 0 R /MediaBox [ 0 0 612 792 ] /Parent 4 0 R /Resources << >> /Type /Page >>
+endobj
+6 0 obj
+<< /Length 0 >>
+stream
+
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000159 00000 n 
+0000000643 00000 n 
+0000000702 00000 n 
+0000000808 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 7 /ID [<7a82e63020abaefab2663adc0e870ef1><7a82e63020abaefab2663adc0e870ef1>] >>
+startxref
+857
+%%EOF


### PR DESCRIPTION
Let user decide whether document-level information, such as outlines, tags, encryption passwords, etc., shall be taken from the first opened file and be preserved in the output file when saving or exporting to a single file. This became the default behavior with PDF Arranger 1.11 using pikepdf version 8 or newer, which uses QPDF jobs. Prior to that, the output was always built starting with a new, empty pdf document and thus all document-level information from the input file was discarded in the output. This old behavior can now be enforced by deactivating the check button "Retain document-level information of the first opened file" in the preferences dialog.
This new check button is only available when working with pikepdf 8 or newer.
<img src="https://github.com/user-attachments/assets/48f2254f-b1b1-4b61-a62e-b71c046073fa" width="300">

Closes #1144 