### PR TITLE
Allow unimposition from the "Split pages" menu

### DIFF
--- a/data/menu.ui
+++ b/data/menu.ui
@@ -194,10 +194,17 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
           <attribute name="label" translatable="yes">Insert Blan_k Page…</attribute>
           <attribute name="action">win.insert-blank-page</attribute>
         </item>
-        <item>
-          <attribute name="label" translatable="yes">Generate Booklet</attribute>
-          <attribute name="action">win.generate-booklet</attribute>
-        </item>
+        <submenu>
+          <attribute name="label" translatable="yes">_Booklet</attribute>
+          <item>
+            <attribute name="label" translatable="yes">_Generate (imposition)</attribute>
+            <attribute name="action">win.generate-booklet</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">_Split (unimposition)</attribute>
+            <attribute name="action">win.split-booklet</attribute>
+          </item>
+        </submenu>
       </section>
     </submenu>
     <submenu>
@@ -462,10 +469,17 @@ along with PDF Arranger.  If not, see <http://www.gnu.org/licenses/>.
         <attribute name="label" translatable="yes">Insert Blan_k Page…</attribute>
         <attribute name="action">win.insert-blank-page</attribute>
       </item>
-      <item>
-        <attribute name="label" translatable="yes">Generate Booklet</attribute>
-        <attribute name="action">win.generate-booklet</attribute>
-      </item>
+      <submenu>
+        <attribute name="label" translatable="yes">_Booklet</attribute>
+        <item>
+          <attribute name="label" translatable="yes">_Generate (imposition)</attribute>
+          <attribute name="action">win.generate-booklet</attribute>
+        </item>
+        <item>
+          <attribute name="label" translatable="yes">_Split (unimposition)</attribute>
+          <attribute name="action">win.split-booklet</attribute>
+        </item>
+      </submenu>
     </section>
     <section>
       <submenu>

--- a/pdfarranger/splitter.py
+++ b/pdfarranger/splitter.py
@@ -164,48 +164,48 @@ class Dialog(Gtk.Dialog):
         self.even_splits[direction] = button.get_active()
         self._update_split(None, direction)
 
-    def _crops(self, direction):
-        # Convert the tile sizes into a list of tuples (start, end) such that
-        # tile size = end - start.
-        num_splits = len(self.model[direction])
-        crops = [(0, 0.01 * self.model[direction][0][1])] * num_splits
-        crop_sum = 0.01 * self.model[direction][0][1]
-        for i in range(1, num_splits):
-            size = 0.01 * self.model[direction][i][1]
-            crop_sum += size
-            crops[i] = (crops[i-1][1], crops[i-1][1] + size)
-
-        # Remove zero-sized tiles
-        crops = [t for t in crops if t[0] < t[1]]
-
-        overlap = crop_sum - 1.0 # nonnegative
-        if overlap == 0.0:
-            return crops
-
-        # We have multiple splits and crop_sum > 1.0
-        # 35,35,35 => [0,35],[32.5,67.5],[65,100]; overlap = 5
-        # 60,60 => [0,60],[40,100]; overlap = 20
-        # In general:
-        #   [start=last-overlap/(num_splits-1),end=start+size]
-        overlap_per_tile = overlap / (num_splits - 1)
-
-        # Overlap is only defined when all tiles have the same size.
-        size = 0.01 * self.model[direction][0][1]
-        crops[0] = (0, size)
-        for i in range(1, num_splits - 1):
-            start = crops[i-1][1] - overlap_per_tile
-            end = start + size
-            crops[i] = (start, end)
-        crops[-1] = (1.0 - size, 1.0)
-        return crops
-
-
     def run_get(self):
         result = self.run()
         vcrops = None
         hcrops = None
         if result == Gtk.ResponseType.OK:
-            vcrops = self._crops('vertical')
-            hcrops = self._crops('horizontal')
+            vcrops = _crops(self.model['vertical'])
+            hcrops = _crops(self.model['horizontal'])
         self.destroy()
         return vcrops, hcrops
+
+# Operates over a 1D-array of [PAGE_N, FRAC] arrays
+def _crops(linear_tiles):
+    # Convert the tile sizes into a list of tuples (start, end) such that
+    # tile size = end - start.
+    num_splits = len(linear_tiles)
+    crops = [(0, 0.01 * linear_tiles[0][1])] * num_splits
+    crop_sum = 0.01 * linear_tiles[0][1]
+    for i in range(1, num_splits):
+        size = 0.01 * linear_tiles[i][1]
+        crop_sum += size
+        crops[i] = (crops[i-1][1], crops[i-1][1] + size)
+
+    # Remove zero-sized tiles
+    crops = [t for t in crops if t[0] < t[1]]
+
+    overlap = crop_sum - 1.0 # nonnegative
+    if overlap == 0.0:
+        return crops
+
+    # We have multiple splits and crop_sum > 1.0
+    # 35,35,35 => [0,35],[32.5,67.5],[65,100]; overlap = 5
+    # 60,60 => [0,60],[40,100]; overlap = 20
+    # In general:
+    #   [start=last-overlap/(num_splits-1),end=start+size]
+    overlap_per_tile = overlap / (num_splits - 1)
+
+    # Overlap is only defined when all tiles have the same size.
+    size = 0.01 * linear_tiles[0][1]
+    crops[0] = (0, size)
+    for i in range(1, num_splits - 1):
+        start = crops[i-1][1] - overlap_per_tile
+        end = start + size
+        crops[i] = (start, end)
+    crops[-1] = (1.0 - size, 1.0)
+    return crops

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-24 20:19+0100\n"
+"POT-Creation-Date: 2024-12-13 13:50+0100\n"
 "PO-Revision-Date: 2024-02-24 20:47+0100\n"
 "Last-Translator: Jérôme Robert <jeromerobert@gmx.com>\n"
 "Language-Team: \n"
@@ -32,80 +32,80 @@ msgstr "#Col"
 msgid "#Row"
 msgstr "#Lig"
 
-#: pdfarranger/pageutils.py:127 pdfarranger/pageutils.py:453
-#: pdfarranger/pageutils.py:455
+#: pdfarranger/pageutils.py:127 pdfarranger/pageutils.py:549
+#: pdfarranger/pageutils.py:551
 msgid "%"
 msgstr "%"
 
-#: pdfarranger/pageutils.py:176
+#: pdfarranger/pageutils.py:275
 #, python-format
 msgid "% of height"
 msgstr "% de la hauteur"
 
-#: pdfarranger/pageutils.py:176
+#: pdfarranger/pageutils.py:275
 #, python-format
 msgid "% of width"
 msgstr "% de la largeur"
 
-#: pdfarranger/pdfarranger.py:2764
+#: pdfarranger/pdfarranger.py:3064
 #, python-format
 msgid "%s is a tool for rearranging and modifying PDF files."
 msgstr "%s est un outil pour réorganiser et modifier des fichiers PDF."
 
-#: pdfarranger/config.py:262
+#: pdfarranger/config.py:255
 msgid "(Libhandy missing)"
 msgstr "(Libhandy manquant)"
 
-#: pdfarranger/config.py:254
+#: pdfarranger/config.py:247
 msgid "(Requires restart)"
 msgstr "(Nécessite de redémarrer)"
 
-#: pdfarranger/pdfarranger.py:1144
+#: pdfarranger/pdfarranger.py:1353
 #, python-format
 msgid "A file named \"%s\" already exists. Do you want to replace it?"
 msgstr "Un fichier nommé « %s » existe déjà. Voulez-vous le remplacer ?"
 
-#: data/menu.ui:227 data/menu.ui:391
+#: data/menu.ui:234 data/menu.ui:403
 msgid "All From _Same File"
 msgstr "Pages du _même fichier"
 
-#: pdfarranger/pdfarranger.py:518
+#: pdfarranger/pdfarranger.py:699
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: pdfarranger/pdfarranger.py:470
+#: pdfarranger/pdfarranger.py:500 pdfarranger/pdfarranger.py:571
 msgid "All pages must have the same size."
 msgstr "Toutes les pages doivent avoir la même taille."
 
-#: pdfarranger/pdfarranger.py:506
+#: pdfarranger/pdfarranger.py:687
 msgid "All supported files"
 msgstr "Tous les fichiers pris en charge"
 
-#: pdfarranger/exporter.py:563
+#: pdfarranger/exporter.py:578
 msgid "Auto Rotate"
 msgstr "Rotation automatique"
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Bottom"
 msgstr "En bas"
 
-#: pdfarranger/pageutils.py:386
+#: pdfarranger/pageutils.py:482
 msgid "Bottom to Top"
 msgstr "De bas en haut"
 
-#: pdfarranger/core.py:569
+#: pdfarranger/core.py:568
 msgid "Clipboard image"
 msgstr "Image du presse-papiers"
 
-#: pdfarranger/pageutils.py:369 pdfarranger/splitter.py:60
+#: pdfarranger/pageutils.py:465 pdfarranger/splitter.py:60
 msgid "Columns"
 msgstr "En colonnes"
 
-#: data/menu.ui:141 data/menu.ui:354
+#: data/menu.ui:141 data/menu.ui:366
 msgid "Copy _Image"
 msgstr "Copier l'_image"
 
-#: data/menu.ui:146 data/menu.ui:359
+#: data/menu.ui:146 data/menu.ui:371
 msgid "Copy _Text"
 msgstr "Copier le _texte"
 
@@ -121,15 +121,19 @@ msgstr "Auteur"
 msgid "Creator tool"
 msgstr "Outil"
 
-#: pdfarranger/pageutils.py:846
+#: pdfarranger/pageutils.py:350
+msgid "Crop & Add margins"
+msgstr ""
+
+#: pdfarranger/pageutils.py:942
 msgid "Crop Margins"
 msgstr "Rogner les marges"
 
-#: data/menu.ui:174 data/menu.ui:432
+#: data/menu.ui:174 data/menu.ui:449
 msgid "Crop White Borders"
 msgstr "Rogner au contenu"
 
-#: pdfarranger/pageutils.py:166 pdfarranger/pdfarranger.py:2730
+#: pdfarranger/pageutils.py:265 pdfarranger/pdfarranger.py:3030
 msgid ""
 "Cropping/hiding does not remove any content from the PDF file, it only hides "
 "it."
@@ -137,49 +141,53 @@ msgstr ""
 "Le recadrage/masquage ne supprime aucun contenu du fichier PDF, il ne fait "
 "que le masquer."
 
-#: data/menu.ui:94 data/menu.ui:302
+#: data/menu.ui:94 data/menu.ui:314
 msgid "Cu_t"
 msgstr "C_ouper"
 
-#: pdfarranger/pdfarranger.py:1258
+#: pdfarranger/pageutils.py:153
+msgid "Custom"
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:1467
 msgid "Despite the warnings the document(s) should have no visible issues."
 msgstr ""
 "Malgré les avertissements, le ou les documents ne devraient présenter aucun "
 "problème visible."
 
-#: pdfarranger/pdfarranger.py:993
+#: pdfarranger/pdfarranger.py:1203
 msgid "Discard changes and close?"
 msgstr "Annuler les modifications et fermer ?"
 
-#: pdfarranger/pdfarranger.py:1030
+#: pdfarranger/pdfarranger.py:1240
 msgid "Discard changes and quit?"
 msgstr "Annuler les modifications et quitter ?"
 
-#: pdfarranger/pdfarranger.py:2737
+#: pdfarranger/pdfarranger.py:3037
 msgid "Do not show this dialog again."
 msgstr "Ne plus demander."
 
-#: pdfarranger/pdfarranger.py:984
+#: pdfarranger/pdfarranger.py:1194
 msgid "Do_n’t Save"
 msgstr "Ne _pas enregistrer"
 
-#: pdfarranger/pdfarranger.py:1265
+#: pdfarranger/pdfarranger.py:1474
 msgid "Don't show warnings when saving again."
 msgstr "Ne plus montrer cet avertissement."
 
-#: data/menu.ui:178 data/menu.ui:436
+#: data/menu.ui:178 data/menu.ui:453
 msgid "Dupl_icate"
 msgstr "D_upliquer"
 
-#: data/menu.ui:52 data/menu.ui:462
+#: data/menu.ui:52 data/menu.ui:486
 msgid "E_xport"
 msgstr "E_xporter"
 
-#: data/menu.ui:55 data/menu.ui:465
+#: data/menu.ui:55 data/menu.ui:489
 msgid "E_xport Selection to a Single File…"
 msgstr "E_xporter la sélection vers un seul fichier…"
 
-#: data/menu.ui:266
+#: data/menu.ui:278
 msgid "Edit _Properties"
 msgstr "Édi_ter les propriétés"
 
@@ -195,60 +203,67 @@ msgstr "Colonnes de largeurs égales"
 msgid "Equal row height"
 msgstr "Lignes de hauteurs égales"
 
-#: pdfarranger/pdfarranger.py:1792
+#: pdfarranger/pdfarranger.py:2003
 msgid "Exploding into images…"
 msgstr "Extraire les images…"
 
-#: data/menu.ui:60 data/menu.ui:470
+#: data/menu.ui:60 data/menu.ui:494
 msgid "Export Selection to _Individual Files…"
 msgstr "Exporter chaque page sélect_ionnée vers un fichier…"
 
-#: data/menu.ui:65 data/menu.ui:475
+#: data/menu.ui:65 data/menu.ui:499
 msgid "Export _All Pages to Individual Files…"
 msgstr "Exporter ch_aque page vers un fichier…"
 
-#: pdfarranger/pdfarranger.py:1102
+#: pdfarranger/pdfarranger.py:1311
 msgid "Export…"
 msgstr "Exporter…"
 
-#: pdfarranger/core.py:571 pdfarranger/pdfarranger.py:1512
+#: pdfarranger/core.py:570 pdfarranger/pdfarranger.py:1721
 msgid "File is neither pdf nor image"
 msgstr "Le fichier n’est ni un PDF ni une image"
 
-#: pdfarranger/pdfarranger.py:300
+#: pdfarranger/pdfarranger.py:329
 msgid "File(s) to open"
 msgstr "Fichier(s) à ouvrir"
 
-#: pdfarranger/exporter.py:561
+#: pdfarranger/pageutils.py:346
+msgid "Fit mode"
+msgstr ""
+
+#: pdfarranger/exporter.py:576
 msgid "Fit to Full Page"
 msgstr "Ajuster à la page entière"
 
-#: pdfarranger/exporter.py:560
+#: pdfarranger/exporter.py:575
 msgid "Fit to Printable Area"
 msgstr "Ajuster à la zone d'impression"
 
-#: pdfarranger/pdfarranger.py:2734
+#: pdfarranger/pageutils.py:355
+msgid "Fit to paper"
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3034
 msgid "For more info see"
 msgstr "Pour plus d'information voir:"
 
-#: pdfarranger/config.py:271
+#: pdfarranger/config.py:264
 msgid "For more options see:"
 msgstr "Pour plus d'options voir:"
 
-#: data/menu.ui:259
+#: data/menu.ui:271
 msgid "Full_screen"
 msgstr "Plein _écran"
 
-#: pdfarranger/pdfarranger.py:2778
+#: pdfarranger/pdfarranger.py:3080
 msgid "GNU General Public License (GPL) Version 3."
 msgstr "Licence publique générale GNU (GPL), version 3."
 
-#: data/menu.ui:198 data/menu.ui:456
-msgid "Generate Booklet"
-msgstr "Générer un livret"
+#: data/menu.ui:200 data/menu.ui:475
+msgid "Generate (imposition)"
+msgstr "Générer (imposition)"
 
-#: pdfarranger/pageutils.py:248 pdfarranger/pageutils.py:252
-#: pdfarranger/pageutils.py:334
+#: pdfarranger/pageutils.py:144
 msgid "Height"
 msgstr "Hauteur"
 
@@ -256,11 +271,11 @@ msgstr "Hauteur"
 msgid "Height in %"
 msgstr "Hauteur en %"
 
-#: pdfarranger/pageutils.py:846
+#: pdfarranger/pageutils.py:942
 msgid "Hide Margins"
 msgstr "Cacher les marges"
 
-#: pdfarranger/pageutils.py:381
+#: pdfarranger/pageutils.py:477
 msgid "Horizontal"
 msgstr "Horizontal"
 
@@ -268,19 +283,19 @@ msgstr "Horizontal"
 msgid "Horizontal Splits"
 msgstr "Nombre de lignes"
 
-#: pdfarranger/pageutils.py:452
+#: pdfarranger/pageutils.py:548
 msgid "Horizontal offset"
 msgstr "Décalage horizontal"
 
-#: pdfarranger/core.py:560
+#: pdfarranger/core.py:559
 msgid "Image files are only supported with img2pdf"
 msgstr "Les fichiers image sont seulement pris en charge avec img2pdf"
 
-#: pdfarranger/core.py:566
+#: pdfarranger/core.py:565
 msgid "Image format is not supported by img2pdf"
 msgstr "Le format d’image n’est pas pris en charge par img2pdf"
 
-#: pdfarranger/pdfarranger.py:1789
+#: pdfarranger/pdfarranger.py:2000
 msgid "Img2pdf missing."
 msgstr "img2pdf introuvable."
 
@@ -288,15 +303,15 @@ msgstr "img2pdf introuvable."
 msgid "Import"
 msgstr "Importer"
 
-#: pdfarranger/pdfarranger.py:1335
+#: pdfarranger/pdfarranger.py:1544
 msgid "Import…"
 msgstr "Importer…"
 
-#: data/menu.ui:194 data/menu.ui:452
+#: data/menu.ui:194 data/menu.ui:469
 msgid "Insert Blan_k Page…"
 msgstr "Insérer une page _blanche…"
 
-#: pdfarranger/pageutils.py:331
+#: pdfarranger/pageutils.py:431
 msgid "Insert Blank Page"
 msgstr "Insérer une page blanche"
 
@@ -304,7 +319,7 @@ msgstr "Insérer une page blanche"
 msgid "Invalid date format. Input discarded."
 msgstr "Format de date non valide."
 
-#: pdfarranger/pdfarranger.py:2767
+#: pdfarranger/pdfarranger.py:3067
 #, python-format
 msgid "It uses libqpdf %s, pikepdf %s, GTK %s and Python %s."
 msgstr "Il utilise libqpdf %s, pikepdf %s, GTK %s et Python %s."
@@ -313,15 +328,19 @@ msgstr "Il utilise libqpdf %s, pikepdf %s, GTK %s et Python %s."
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: pdfarranger/config.py:252
+#: pdfarranger/pageutils.py:163
+msgid "Landscape"
+msgstr ""
+
+#: pdfarranger/config.py:245
 msgid "Language"
 msgstr "Langue"
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Left"
 msgstr "À gauche"
 
-#: pdfarranger/pageutils.py:383
+#: pdfarranger/pageutils.py:479
 msgid "Left to Right"
 msgstr "De gauche à droite"
 
@@ -329,19 +348,19 @@ msgstr "De gauche à droite"
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: pdfarranger/pdfarranger.py:2773
+#: pdfarranger/pdfarranger.py:3075
 msgid "Maintainers and contributors"
 msgstr "Mainteneurs et contributeurs"
 
-#: pdfarranger/pageutils.py:367
+#: pdfarranger/pageutils.py:463
 msgid "Margin"
 msgstr "Marges"
 
-#: pdfarranger/pageutils.py:353
+#: pdfarranger/pageutils.py:449
 msgid "Merge Pages"
 msgstr "Fusionner les pages"
 
-#: pdfarranger/pageutils.py:418
+#: pdfarranger/pageutils.py:514
 msgid "Merged page size:"
 msgstr "Taille de la page fusionnée :"
 
@@ -349,19 +368,19 @@ msgstr "Taille de la page fusionnée :"
 msgid "Modified"
 msgstr "Modifié le"
 
-#: pdfarranger/pageutils.py:398
+#: pdfarranger/pageutils.py:494
 msgid "Non-uniform page size - using max size"
 msgstr "Taille de page non uniforme - utilisation de la taille maximale"
 
-#: pdfarranger/exporter.py:559
+#: pdfarranger/exporter.py:574
 msgid "None"
 msgstr "Aucun"
 
-#: pdfarranger/pdfarranger.py:2723
+#: pdfarranger/pdfarranger.py:3023
 msgid "Note"
 msgstr "Note"
 
-#: pdfarranger/pdfarranger.py:2729
+#: pdfarranger/pdfarranger.py:3029
 msgid "Note the limitations:"
 msgstr "Veuillez noter les limitations suivantes:"
 
@@ -369,20 +388,24 @@ msgstr "Veuillez noter les limitations suivantes:"
 msgid "Open"
 msgstr "Ouvrir"
 
-#: pdfarranger/pdfarranger.py:1200
+#: pdfarranger/pdfarranger.py:1409
 msgid "Open…"
 msgstr "Ouvrir…"
 
-#: pdfarranger/pdfarranger.py:2731
+#: pdfarranger/pageutils.py:161
+msgid "Orientation"
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3031
 msgid "Outlines and links can be preserved only in certain cases."
 msgstr ""
 "Les sommaires et les liens ne peuvent être conservés que dans certains cas."
 
-#: pdfarranger/pageutils.py:899
+#: pdfarranger/pageutils.py:995
 msgid "Overlay"
 msgstr "Sur-couche"
 
-#: pdfarranger/pdfarranger.py:281
+#: pdfarranger/pdfarranger.py:310
 msgid ""
 "PDF Arranger is a small python-gtk application, which helps the user to "
 "merge or split pdf documents and rotate, crop and rearrange their pages "
@@ -394,87 +417,91 @@ msgstr ""
 "réorganiser leurs pages en utilisant une interface graphique interactive et "
 "intuitive. C’est une interface pour Pikepdf."
 
-#: pdfarranger/pdfarranger.py:1506
+#: pdfarranger/pdfarranger.py:1715
 msgid "PDF document is damaged"
 msgstr "Le document PDF est endommagé"
 
-#: pdfarranger/pdfarranger.py:510
+#: pdfarranger/pdfarranger.py:691
 msgid "PDF files"
 msgstr "Fichiers PDF"
 
-#: pdfarranger/exporter.py:599
+#: pdfarranger/exporter.py:614
 msgid "Page Handling"
 msgstr "Gestion de page"
 
-#: pdfarranger/pageutils.py:394
+#: pdfarranger/pageutils.py:490
 msgid "Page Order"
 msgstr "Ordre des pages"
 
-#: pdfarranger/pdfarranger.py:2801
-msgid "Page Size:"
-msgstr "Dimensions de la page :"
-
-#: pdfarranger/pageutils.py:243
+#: pdfarranger/pageutils.py:342
 msgid "Page size"
 msgstr "Dimensions de la page"
 
-#: pdfarranger/core.py:457
+#: pdfarranger/pageutils.py:150
+msgid "Paper size"
+msgstr ""
+
+#: pdfarranger/core.py:456
 msgid "Password"
 msgstr "Mot de passe"
 
-#: pdfarranger/core.py:435
+#: pdfarranger/core.py:434
 msgid "Password required"
 msgstr "Mot de passe requis"
 
-#: data/menu.ui:107 data/menu.ui:315
+#: data/menu.ui:107 data/menu.ui:327
 msgid "Past_e Special"
 msgstr "Coll_age spécial"
 
-#: data/menu.ui:124 data/menu.ui:333
+#: data/menu.ui:124 data/menu.ui:345
 msgid "Paste As O_verlay…"
 msgstr "Coller en s_ur-couche…"
 
-#: data/menu.ui:119 data/menu.ui:328
+#: data/menu.ui:119 data/menu.ui:340
 msgid "Paste As _Even Pages"
 msgstr "Coller en pages _paires"
 
-#: data/menu.ui:114 data/menu.ui:323
+#: data/menu.ui:114 data/menu.ui:335
 msgid "Paste As _Odd Pages"
 msgstr "Coller en pages i_mpaires"
 
-#: data/menu.ui:129 data/menu.ui:338
+#: data/menu.ui:129 data/menu.ui:350
 msgid "Paste As _Underlay…"
 msgstr "Coller en s_ous-couche…"
 
-#: data/menu.ui:102 data/menu.ui:310
+#: data/menu.ui:102 data/menu.ui:322
 msgid "Paste _After"
 msgstr "Co_ller après"
 
-#: data/menu.ui:109 data/menu.ui:318
+#: data/menu.ui:109 data/menu.ui:330
 msgid "Paste _Before"
 msgstr "Coller a_vant"
 
-#: pdfarranger/pdfarranger.py:1636
+#: pdfarranger/pdfarranger.py:1847
 msgid "Pasted data not valid. Aborting paste."
 msgstr "Données collées non valides. Annulation du collage."
 
-#: data/menu.ui:272
+#: pdfarranger/pageutils.py:162
+msgid "Portrait"
+msgstr ""
+
+#: data/menu.ui:284
 msgid "Pre_ferences"
 msgstr "Pré_férences"
 
-#: pdfarranger/config.py:242
+#: pdfarranger/config.py:235
 msgid "Preferences"
 msgstr "Préférences"
 
-#: pdfarranger/pdfarranger.py:292
+#: pdfarranger/pdfarranger.py:321
 msgid "Print the version of PDF Arranger and exit"
 msgstr "Affiche la version de PDF Arranger et quitte"
 
-#: pdfarranger/config.py:267
+#: pdfarranger/config.py:260
 msgid "Printing"
 msgstr "Impression"
 
-#: pdfarranger/exporter.py:579
+#: pdfarranger/exporter.py:594
 msgid "Printing…"
 msgstr "Impression…"
 
@@ -486,31 +513,35 @@ msgstr "Producteur"
 msgid "Property"
 msgstr "Propriété"
 
-#: data/menu.ui:182 data/menu.ui:440
+#: pdfarranger/pageutils.py:1060
+msgid "Range Select"
+msgstr ""
+
+#: data/menu.ui:182 data/menu.ui:457
 msgid "Re_verse Order"
 msgstr "_Inverser l’ordre"
 
-#: pdfarranger/pageutils.py:250
+#: pdfarranger/pageutils.py:356
 msgid "Relative"
 msgstr "Relative"
 
-#: pdfarranger/exporter.py:617
+#: pdfarranger/exporter.py:632
 msgid "Rendering Preview…"
 msgstr "Rendu des aperçus…"
 
-#: pdfarranger/pdfarranger.py:746
+#: pdfarranger/pdfarranger.py:955
 msgid "Rendering…"
 msgstr "Calcul du rendu…"
 
-#: pdfarranger/pdfarranger.py:1146
+#: pdfarranger/pdfarranger.py:1355
 msgid "Replace"
 msgstr "Remplacer"
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Right"
 msgstr "À droite"
 
-#: pdfarranger/pageutils.py:384
+#: pdfarranger/pageutils.py:480
 msgid "Right to Left"
 msgstr "De droite à gauche"
 
@@ -522,15 +553,20 @@ msgstr "Rotation vers la gauche"
 msgid "Rotate Right"
 msgstr "Rotation vers la droite"
 
-#: data/menu.ui:152 data/menu.ui:410
+#: data/menu.ui:152 data/menu.ui:427
 msgid "Rotate _Left"
 msgstr "Rotation vers la _gauche"
 
-#: pdfarranger/pageutils.py:370 pdfarranger/splitter.py:60
+#: pdfarranger/pageutils.py:466 pdfarranger/splitter.py:60
 msgid "Rows"
 msgstr "En lignes"
 
-#: data/menu.ui:232 data/menu.ui:396
+#: pdfarranger/pdfarranger.py:3070
+#, python-format
+msgid "Running on %s"
+msgstr ""
+
+#: data/menu.ui:239 data/menu.ui:408
 msgid "Same Page _Format"
 msgstr "Pages de même _format"
 
@@ -542,7 +578,7 @@ msgstr "Enregistrer"
 msgid "Save As"
 msgstr "Enregistrer sous"
 
-#: pdfarranger/pdfarranger.py:1102
+#: pdfarranger/pdfarranger.py:1311
 msgid "Save As…"
 msgstr "Enregistrer sous…"
 
@@ -550,57 +586,77 @@ msgstr "Enregistrer sous…"
 msgid "Save _As…"
 msgstr "Enregistrer _sous…"
 
-#: pdfarranger/pdfarranger.py:1002
+#: pdfarranger/pdfarranger.py:1212
 msgid "Save changes before closing?"
 msgstr "Enregistrer les modifications avant la fermeture ?"
 
-#: pdfarranger/pdfarranger.py:1039
+#: pdfarranger/pdfarranger.py:1249
 msgid "Save changes before quitting?"
 msgstr "Enregistrer les modifications avant de quitter ?"
 
-#: pdfarranger/pdfarranger.py:999
+#: pdfarranger/pdfarranger.py:1209
 msgid "Save changes to “{}” before closing?"
 msgstr "Enregistrer les modifications du document « {} » avant la fermeture ?"
 
-#: pdfarranger/pdfarranger.py:1036
+#: pdfarranger/pdfarranger.py:1246
 msgid "Save changes to “{}” before quitting?"
 msgstr "Enregistrer les modifications dans « {} » avant de quitter ?"
 
-#: pdfarranger/pdfarranger.py:1257
+#: pdfarranger/pdfarranger.py:1466
 msgid "Saving produced some warnings"
 msgstr "La sauvegarde a produit des avertissements"
 
-#: pdfarranger/pdfarranger.py:1296
+#: pdfarranger/pdfarranger.py:1505
 msgid "Saving…"
 msgstr "Enregistrer…"
+
+#: pdfarranger/pageutils.py:348
+msgid "Scale"
+msgstr ""
+
+#: pdfarranger/pageutils.py:349
+msgid "Scale & Add margins"
+msgstr ""
 
 #: pdfarranger/pageutils.py:121
 msgid "Scale factor"
 msgstr "Facteur d’échelle"
 
-#: pdfarranger/exporter.py:557
+#: pdfarranger/exporter.py:572
 msgid "Scale mode:"
 msgstr "Mode d'ajustement:"
 
-#: data/menu.ui:207 data/menu.ui:371
+#: data/menu.ui:214 data/menu.ui:383
 msgid "Select _All"
 msgstr "_Tout sélectionner"
 
-#: data/menu.ui:222 data/menu.ui:386
+#: data/menu.ui:229 data/menu.ui:398
 msgid "Select _Even Pages"
 msgstr "Pages _paires"
 
-#: data/menu.ui:217 data/menu.ui:381
+#: data/menu.ui:224 data/menu.ui:393
 msgid "Select _Odd Pages"
 msgstr "Pages _impaires"
 
-#: pdfarranger/pdfarranger.py:2796
+#: data/menu.ui:249 data/menu.ui:418
+msgid "Select _Range"
+msgstr ""
+
+#: pdfarranger/pageutils.py:1069
+msgid "Select range of pages: "
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3098
 msgid "Selected pages: "
 msgstr "Pages sélectionnées : "
 
-#: pdfarranger/pageutils.py:548
+#: pdfarranger/pageutils.py:644
 msgid "Show values"
 msgstr "Montrer les valeurs"
+
+#: data/menu.ui:204 data/menu.ui:479
+msgid "Split (unimposition)"
+msgstr "Séparer (désimposition)"
 
 #: pdfarranger/splitter.py:26
 msgid "Split Pages"
@@ -610,31 +666,35 @@ msgstr "Séparer les pages"
 msgid "Subject"
 msgstr "Sujet"
 
-#: pdfarranger/pdfarranger.py:523
+#: pdfarranger/pdfarranger.py:704
 msgid "Supported image files"
 msgstr "Fichiers image pris en charge"
 
-#: pdfarranger/config.py:282 pdfarranger/config.py:290
+#: pdfarranger/config.py:275 pdfarranger/config.py:283
 msgid "System setting"
 msgstr "Configuration système"
 
-#: pdfarranger/core.py:447
+#: pdfarranger/core.py:446
 msgid ""
 "The document “{}” is locked and requires a password before it can be opened."
 msgstr ""
 "Le document « {} » est verrouillé et nécessite un mot de passe avant son "
 "ouverture."
 
-#: pdfarranger/pdfarranger.py:1765
+#: pdfarranger/pdfarranger.py:1976
 msgid "The page has several images. Use \"Explode into Images\" first.\""
 msgstr ""
 "La page contient plusieurs images. Utilisez d'abord \"Extraire les images\"."
 
-#: pdfarranger/core.py:446
+#: pdfarranger/pdfarranger.py:558
+msgid "The page selection is not contiguous. Cannot unimpose."
+msgstr "La sélection de pages n'est pas contigue. Impossible de désimposer."
+
+#: pdfarranger/core.py:445
 msgid "The password will be remembered until you close PDF Arranger."
 msgstr "Le mot de passe sera mémorisé jusqu’à la fermeture de PDF Arranger."
 
-#: pdfarranger/config.py:260
+#: pdfarranger/config.py:253
 msgid "Theme"
 msgstr "Thème"
 
@@ -642,23 +702,29 @@ msgstr "Thème"
 msgid "Title"
 msgstr "Titre"
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Top"
 msgstr "En haut"
 
-#: pdfarranger/pageutils.py:385
+#: pdfarranger/pageutils.py:481
 msgid "Top to Bottom"
 msgstr "De haut en bas"
 
-#: pdfarranger/pageutils.py:899
+#: pdfarranger/pageutils.py:995
 msgid "Underlay"
 msgstr "Sous-couche"
 
-#: pdfarranger/core.py:544 pdfarranger/pdfarranger.py:1502
+#: pdfarranger/core.py:543 pdfarranger/pdfarranger.py:1711
 msgid "Unknown file format"
 msgstr "Format de fichier inconnu"
 
-#: pdfarranger/pdfarranger.py:2735
+#: pdfarranger/pageutils.py:1076
+msgid ""
+"Use a comma to separate page numbers, a dash to select a range of pages. \n"
+"e.g. : \"1,3,5-7,9\""
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3035
 msgid "User Manual"
 msgstr "Manuel utilisateur"
 
@@ -666,7 +732,7 @@ msgstr "Manuel utilisateur"
 msgid "Value"
 msgstr "Valeur"
 
-#: pdfarranger/pageutils.py:382
+#: pdfarranger/pageutils.py:478
 msgid "Vertical"
 msgstr "Vertical"
 
@@ -674,12 +740,11 @@ msgstr "Vertical"
 msgid "Vertical Splits"
 msgstr "Nombre de colonnes"
 
-#: pdfarranger/pageutils.py:454
+#: pdfarranger/pageutils.py:550
 msgid "Vertical offset"
 msgstr "Décalage vertical"
 
-#: pdfarranger/pageutils.py:247 pdfarranger/pageutils.py:251
-#: pdfarranger/pageutils.py:333
+#: pdfarranger/pageutils.py:138
 msgid "Width"
 msgstr "Largeur"
 
@@ -687,7 +752,7 @@ msgstr "Largeur"
 msgid "Width in %"
 msgstr "Largeur en %"
 
-#: pdfarranger/pdfarranger.py:983
+#: pdfarranger/pdfarranger.py:1193
 msgid "Your changes will be lost if you don’t save them."
 msgstr "Vos modifications seront perdues si vous ne les enregistrez pas."
 
@@ -699,49 +764,54 @@ msgstr "Zoom avant"
 msgid "Zoom Out"
 msgstr "Zoom arrière"
 
-#: data/menu.ui:255
+#: data/menu.ui:267
 msgid "Zoom _Fit"
 msgstr "Zoom _ajusté"
 
-#: data/menu.ui:247
+#: data/menu.ui:259
 msgid "Zoom _In"
 msgstr "Zoom a_vant"
 
-#: data/menu.ui:251
+#: data/menu.ui:263
 msgid "Zoom _Out"
 msgstr "Zoom _arrière"
 
-#: data/menu.ui:278
+#: data/menu.ui:290
 msgid "_About"
 msgstr "À _propos"
 
-#: pdfarranger/pageutils.py:856
+#: pdfarranger/pageutils.py:952
 msgid "_Apply"
 msgstr "_Appliquer"
 
-#: pdfarranger/config.py:246 pdfarranger/pageutils.py:227
-#: pdfarranger/pdfarranger.py:975 pdfarranger/pdfarranger.py:984
-#: pdfarranger/pdfarranger.py:1108 pdfarranger/pdfarranger.py:1158
+#: data/menu.ui:198 data/menu.ui:473
+msgid "_Booklet"
+msgstr ""
+
+#: pdfarranger/config.py:239 pdfarranger/metadata.py:205
+#: pdfarranger/pageutils.py:326 pdfarranger/pdfarranger.py:1185
+#: pdfarranger/pdfarranger.py:1194 pdfarranger/pdfarranger.py:1317
+#: pdfarranger/pdfarranger.py:1367
 msgid "_Cancel"
 msgstr "A_nnuler"
 
-#: pdfarranger/pdfarranger.py:994 data/menu.ui:284
+#: pdfarranger/pdfarranger.py:1204 data/menu.ui:296
 msgid "_Close"
 msgstr "_Fermer"
 
-#: data/menu.ui:98 data/menu.ui:306
+#: data/menu.ui:98 data/menu.ui:318
 msgid "_Copy"
 msgstr "_Copier"
 
-#: data/menu.ui:166 data/menu.ui:424
+#: data/menu.ui:166 data/menu.ui:441
 msgid "_Crop Margins…"
 msgstr "_Rogner les marges…"
 
-#: data/menu.ui:90 data/menu.ui:298
+#: data/menu.ui:90 data/menu.ui:310
 msgid "_Delete"
 msgstr "_Supprimer"
 
-#: data/menu.ui:212 data/menu.ui:376
+#: data/menu.ui:219 data/menu.ui:388
 msgid "_Deselect All"
 msgstr "Tout _désélectionner"
 
@@ -749,15 +819,15 @@ msgstr "Tout _désélectionner"
 msgid "_Edit"
 msgstr "É_dition"
 
-#: data/menu.ui:137 data/menu.ui:350
+#: data/menu.ui:137 data/menu.ui:362
 msgid "_Explode into Images"
 msgstr "_Extraire les images"
 
-#: data/menu.ui:135 data/menu.ui:347
+#: data/menu.ui:135 data/menu.ui:359
 msgid "_Extract"
 msgstr "_Extraire"
 
-#: data/menu.ui:170 data/menu.ui:428
+#: data/menu.ui:170 data/menu.ui:445
 msgid "_Hide Margins…"
 msgstr "_Cacher les marges…"
 
@@ -765,11 +835,11 @@ msgstr "_Cacher les marges…"
 msgid "_Import"
 msgstr "_Importer"
 
-#: data/menu.ui:237 data/menu.ui:401
+#: data/menu.ui:244 data/menu.ui:413
 msgid "_Invert Selection"
 msgstr "_Inverser la sélection"
 
-#: data/menu.ui:190 data/menu.ui:448
+#: data/menu.ui:190 data/menu.ui:465
 msgid "_Merge Pages…"
 msgstr "_Fusionner les pages…"
 
@@ -777,15 +847,16 @@ msgstr "_Fusionner les pages…"
 msgid "_New Window"
 msgstr "_Nouvelle fenêtre"
 
-#: pdfarranger/config.py:247 pdfarranger/pageutils.py:228
+#: pdfarranger/config.py:240 pdfarranger/metadata.py:206
+#: pdfarranger/pageutils.py:327 pdfarranger/pdfarranger.py:3026
 msgid "_OK"
 msgstr "_OK"
 
-#: pdfarranger/pdfarranger.py:1157 data/menu.ui:24
+#: pdfarranger/pdfarranger.py:1366 data/menu.ui:24
 msgid "_Open"
 msgstr "_Ouvrir"
 
-#: data/menu.ui:162 data/menu.ui:420
+#: data/menu.ui:162 data/menu.ui:437
 msgid "_Page Size…"
 msgstr "_Dimensions de page…"
 
@@ -793,7 +864,7 @@ msgstr "_Dimensions de page…"
 msgid "_Print…"
 msgstr "_Imprimer…"
 
-#: pdfarranger/pdfarranger.py:1031 data/menu.ui:290
+#: pdfarranger/pdfarranger.py:1241 data/menu.ui:302
 msgid "_Quit"
 msgstr "_Quitter"
 
@@ -801,24 +872,24 @@ msgstr "_Quitter"
 msgid "_Redo"
 msgstr "_Rétablir"
 
-#: pdfarranger/pageutils.py:856
+#: pdfarranger/pageutils.py:952
 msgid "_Revert"
 msgstr "_Rétablir"
 
-#: data/menu.ui:157 data/menu.ui:415
+#: data/menu.ui:157 data/menu.ui:432
 msgid "_Rotate Right"
 msgstr "Rotation vers la _droite"
 
-#: pdfarranger/pdfarranger.py:984 pdfarranger/pdfarranger.py:1107
+#: pdfarranger/pdfarranger.py:1194 pdfarranger/pdfarranger.py:1316
 #: data/menu.ui:42
 msgid "_Save"
 msgstr "_Enregistrer"
 
-#: data/menu.ui:204 data/menu.ui:368
+#: data/menu.ui:211 data/menu.ui:380
 msgid "_Select"
 msgstr "_Sélectionner"
 
-#: data/menu.ui:186 data/menu.ui:444
+#: data/menu.ui:186 data/menu.ui:461
 msgid "_Split Pages…"
 msgstr "_Séparer les pages…"
 
@@ -826,19 +897,19 @@ msgstr "_Séparer les pages…"
 msgid "_Undo"
 msgstr "Ann_uler"
 
-#: data/menu.ui:244
+#: data/menu.ui:256
 msgid "_View"
 msgstr "_Vue"
 
-#: pdfarranger/pageutils.py:144 pdfarranger/pageutils.py:368
-#: pdfarranger/pageutils.py:418
+#: pdfarranger/pageutils.py:142 pdfarranger/pageutils.py:148
+#: pdfarranger/pageutils.py:464 pdfarranger/pageutils.py:514
 msgid "mm"
 msgstr "mm"
 
-#: pdfarranger/core.py:326
+#: pdfarranger/core.py:695
 msgid "page"
 msgstr "page"
 
-#: pdfarranger/pdfarranger.py:825
+#: pdfarranger/pdfarranger.py:1035
 msgid "untitled"
 msgstr "sans titre"

--- a/po/pdfarranger.pot
+++ b/po/pdfarranger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-24 20:19+0100\n"
+"POT-Creation-Date: 2024-12-13 13:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,80 +25,80 @@ msgstr ""
 msgid "#Row"
 msgstr ""
 
-#: pdfarranger/pageutils.py:127 pdfarranger/pageutils.py:453
-#: pdfarranger/pageutils.py:455
+#: pdfarranger/pageutils.py:127 pdfarranger/pageutils.py:549
+#: pdfarranger/pageutils.py:551
 msgid "%"
 msgstr ""
 
-#: pdfarranger/pageutils.py:176
+#: pdfarranger/pageutils.py:275
 #, python-format
 msgid "% of height"
 msgstr ""
 
-#: pdfarranger/pageutils.py:176
+#: pdfarranger/pageutils.py:275
 #, python-format
 msgid "% of width"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2764
+#: pdfarranger/pdfarranger.py:3064
 #, python-format
 msgid "%s is a tool for rearranging and modifying PDF files."
 msgstr ""
 
-#: pdfarranger/config.py:262
+#: pdfarranger/config.py:255
 msgid "(Libhandy missing)"
 msgstr ""
 
-#: pdfarranger/config.py:254
+#: pdfarranger/config.py:247
 msgid "(Requires restart)"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1144
+#: pdfarranger/pdfarranger.py:1353
 #, python-format
 msgid "A file named \"%s\" already exists. Do you want to replace it?"
 msgstr ""
 
-#: data/menu.ui:227 data/menu.ui:391
+#: data/menu.ui:234 data/menu.ui:403
 msgid "All From _Same File"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:518
+#: pdfarranger/pdfarranger.py:699
 msgid "All files"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:470
+#: pdfarranger/pdfarranger.py:500 pdfarranger/pdfarranger.py:571
 msgid "All pages must have the same size."
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:506
+#: pdfarranger/pdfarranger.py:687
 msgid "All supported files"
 msgstr ""
 
-#: pdfarranger/exporter.py:563
+#: pdfarranger/exporter.py:578
 msgid "Auto Rotate"
 msgstr ""
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Bottom"
 msgstr ""
 
-#: pdfarranger/pageutils.py:386
+#: pdfarranger/pageutils.py:482
 msgid "Bottom to Top"
 msgstr ""
 
-#: pdfarranger/core.py:569
+#: pdfarranger/core.py:568
 msgid "Clipboard image"
 msgstr ""
 
-#: pdfarranger/pageutils.py:369 pdfarranger/splitter.py:60
+#: pdfarranger/pageutils.py:465 pdfarranger/splitter.py:60
 msgid "Columns"
 msgstr ""
 
-#: data/menu.ui:141 data/menu.ui:354
+#: data/menu.ui:141 data/menu.ui:366
 msgid "Copy _Image"
 msgstr ""
 
-#: data/menu.ui:146 data/menu.ui:359
+#: data/menu.ui:146 data/menu.ui:371
 msgid "Copy _Text"
 msgstr ""
 
@@ -114,61 +114,69 @@ msgstr ""
 msgid "Creator tool"
 msgstr ""
 
-#: pdfarranger/pageutils.py:846
+#: pdfarranger/pageutils.py:350
+msgid "Crop & Add margins"
+msgstr ""
+
+#: pdfarranger/pageutils.py:942
 msgid "Crop Margins"
 msgstr ""
 
-#: data/menu.ui:174 data/menu.ui:432
+#: data/menu.ui:174 data/menu.ui:449
 msgid "Crop White Borders"
 msgstr ""
 
-#: pdfarranger/pageutils.py:166 pdfarranger/pdfarranger.py:2730
+#: pdfarranger/pageutils.py:265 pdfarranger/pdfarranger.py:3030
 msgid ""
 "Cropping/hiding does not remove any content from the PDF file, it only hides "
 "it."
 msgstr ""
 
-#: data/menu.ui:94 data/menu.ui:302
+#: data/menu.ui:94 data/menu.ui:314
 msgid "Cu_t"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1258
+#: pdfarranger/pageutils.py:153
+msgid "Custom"
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:1467
 msgid "Despite the warnings the document(s) should have no visible issues."
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:993
+#: pdfarranger/pdfarranger.py:1203
 msgid "Discard changes and close?"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1030
+#: pdfarranger/pdfarranger.py:1240
 msgid "Discard changes and quit?"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2737
+#: pdfarranger/pdfarranger.py:3037
 msgid "Do not show this dialog again."
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:984
+#: pdfarranger/pdfarranger.py:1194
 msgid "Do_n’t Save"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1265
+#: pdfarranger/pdfarranger.py:1474
 msgid "Don't show warnings when saving again."
 msgstr ""
 
-#: data/menu.ui:178 data/menu.ui:436
+#: data/menu.ui:178 data/menu.ui:453
 msgid "Dupl_icate"
 msgstr ""
 
-#: data/menu.ui:52 data/menu.ui:462
+#: data/menu.ui:52 data/menu.ui:486
 msgid "E_xport"
 msgstr ""
 
-#: data/menu.ui:55 data/menu.ui:465
+#: data/menu.ui:55 data/menu.ui:489
 msgid "E_xport Selection to a Single File…"
 msgstr ""
 
-#: data/menu.ui:266
+#: data/menu.ui:278
 msgid "Edit _Properties"
 msgstr ""
 
@@ -184,60 +192,67 @@ msgstr ""
 msgid "Equal row height"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1792
+#: pdfarranger/pdfarranger.py:2003
 msgid "Exploding into images…"
 msgstr ""
 
-#: data/menu.ui:60 data/menu.ui:470
+#: data/menu.ui:60 data/menu.ui:494
 msgid "Export Selection to _Individual Files…"
 msgstr ""
 
-#: data/menu.ui:65 data/menu.ui:475
+#: data/menu.ui:65 data/menu.ui:499
 msgid "Export _All Pages to Individual Files…"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1102
+#: pdfarranger/pdfarranger.py:1311
 msgid "Export…"
 msgstr ""
 
-#: pdfarranger/core.py:571 pdfarranger/pdfarranger.py:1512
+#: pdfarranger/core.py:570 pdfarranger/pdfarranger.py:1721
 msgid "File is neither pdf nor image"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:300
+#: pdfarranger/pdfarranger.py:329
 msgid "File(s) to open"
 msgstr ""
 
-#: pdfarranger/exporter.py:561
+#: pdfarranger/pageutils.py:346
+msgid "Fit mode"
+msgstr ""
+
+#: pdfarranger/exporter.py:576
 msgid "Fit to Full Page"
 msgstr ""
 
-#: pdfarranger/exporter.py:560
+#: pdfarranger/exporter.py:575
 msgid "Fit to Printable Area"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2734
+#: pdfarranger/pageutils.py:355
+msgid "Fit to paper"
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3034
 msgid "For more info see"
 msgstr ""
 
-#: pdfarranger/config.py:271
+#: pdfarranger/config.py:264
 msgid "For more options see:"
 msgstr ""
 
-#: data/menu.ui:259
+#: data/menu.ui:271
 msgid "Full_screen"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2778
+#: pdfarranger/pdfarranger.py:3080
 msgid "GNU General Public License (GPL) Version 3."
 msgstr ""
 
-#: data/menu.ui:198 data/menu.ui:456
-msgid "Generate Booklet"
+#: data/menu.ui:200 data/menu.ui:475
+msgid "Generate (imposition)"
 msgstr ""
 
-#: pdfarranger/pageutils.py:248 pdfarranger/pageutils.py:252
-#: pdfarranger/pageutils.py:334
+#: pdfarranger/pageutils.py:144
 msgid "Height"
 msgstr ""
 
@@ -245,11 +260,11 @@ msgstr ""
 msgid "Height in %"
 msgstr ""
 
-#: pdfarranger/pageutils.py:846
+#: pdfarranger/pageutils.py:942
 msgid "Hide Margins"
 msgstr ""
 
-#: pdfarranger/pageutils.py:381
+#: pdfarranger/pageutils.py:477
 msgid "Horizontal"
 msgstr ""
 
@@ -257,19 +272,19 @@ msgstr ""
 msgid "Horizontal Splits"
 msgstr ""
 
-#: pdfarranger/pageutils.py:452
+#: pdfarranger/pageutils.py:548
 msgid "Horizontal offset"
 msgstr ""
 
-#: pdfarranger/core.py:560
+#: pdfarranger/core.py:559
 msgid "Image files are only supported with img2pdf"
 msgstr ""
 
-#: pdfarranger/core.py:566
+#: pdfarranger/core.py:565
 msgid "Image format is not supported by img2pdf"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1789
+#: pdfarranger/pdfarranger.py:2000
 msgid "Img2pdf missing."
 msgstr ""
 
@@ -277,15 +292,15 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1335
+#: pdfarranger/pdfarranger.py:1544
 msgid "Import…"
 msgstr ""
 
-#: data/menu.ui:194 data/menu.ui:452
+#: data/menu.ui:194 data/menu.ui:469
 msgid "Insert Blan_k Page…"
 msgstr ""
 
-#: pdfarranger/pageutils.py:331
+#: pdfarranger/pageutils.py:431
 msgid "Insert Blank Page"
 msgstr ""
 
@@ -293,7 +308,7 @@ msgstr ""
 msgid "Invalid date format. Input discarded."
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2767
+#: pdfarranger/pdfarranger.py:3067
 #, python-format
 msgid "It uses libqpdf %s, pikepdf %s, GTK %s and Python %s."
 msgstr ""
@@ -302,15 +317,19 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: pdfarranger/config.py:252
+#: pdfarranger/pageutils.py:163
+msgid "Landscape"
+msgstr ""
+
+#: pdfarranger/config.py:245
 msgid "Language"
 msgstr ""
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Left"
 msgstr ""
 
-#: pdfarranger/pageutils.py:383
+#: pdfarranger/pageutils.py:479
 msgid "Left to Right"
 msgstr ""
 
@@ -318,19 +337,19 @@ msgstr ""
 msgid "Main Menu"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2773
+#: pdfarranger/pdfarranger.py:3075
 msgid "Maintainers and contributors"
 msgstr ""
 
-#: pdfarranger/pageutils.py:367
+#: pdfarranger/pageutils.py:463
 msgid "Margin"
 msgstr ""
 
-#: pdfarranger/pageutils.py:353
+#: pdfarranger/pageutils.py:449
 msgid "Merge Pages"
 msgstr ""
 
-#: pdfarranger/pageutils.py:418
+#: pdfarranger/pageutils.py:514
 msgid "Merged page size:"
 msgstr ""
 
@@ -338,19 +357,19 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
-#: pdfarranger/pageutils.py:398
+#: pdfarranger/pageutils.py:494
 msgid "Non-uniform page size - using max size"
 msgstr ""
 
-#: pdfarranger/exporter.py:559
+#: pdfarranger/exporter.py:574
 msgid "None"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2723
+#: pdfarranger/pdfarranger.py:3023
 msgid "Note"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2729
+#: pdfarranger/pdfarranger.py:3029
 msgid "Note the limitations:"
 msgstr ""
 
@@ -358,19 +377,23 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1200
+#: pdfarranger/pdfarranger.py:1409
 msgid "Open…"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2731
+#: pdfarranger/pageutils.py:161
+msgid "Orientation"
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3031
 msgid "Outlines and links can be preserved only in certain cases."
 msgstr ""
 
-#: pdfarranger/pageutils.py:899
+#: pdfarranger/pageutils.py:995
 msgid "Overlay"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:281
+#: pdfarranger/pdfarranger.py:310
 msgid ""
 "PDF Arranger is a small python-gtk application, which helps the user to "
 "merge or split pdf documents and rotate, crop and rearrange their pages "
@@ -378,87 +401,91 @@ msgid ""
 "pikepdf."
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1506
+#: pdfarranger/pdfarranger.py:1715
 msgid "PDF document is damaged"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:510
+#: pdfarranger/pdfarranger.py:691
 msgid "PDF files"
 msgstr ""
 
-#: pdfarranger/exporter.py:599
+#: pdfarranger/exporter.py:614
 msgid "Page Handling"
 msgstr ""
 
-#: pdfarranger/pageutils.py:394
+#: pdfarranger/pageutils.py:490
 msgid "Page Order"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2801
-msgid "Page Size:"
-msgstr ""
-
-#: pdfarranger/pageutils.py:243
+#: pdfarranger/pageutils.py:342
 msgid "Page size"
 msgstr ""
 
-#: pdfarranger/core.py:457
+#: pdfarranger/pageutils.py:150
+msgid "Paper size"
+msgstr ""
+
+#: pdfarranger/core.py:456
 msgid "Password"
 msgstr ""
 
-#: pdfarranger/core.py:435
+#: pdfarranger/core.py:434
 msgid "Password required"
 msgstr ""
 
-#: data/menu.ui:107 data/menu.ui:315
+#: data/menu.ui:107 data/menu.ui:327
 msgid "Past_e Special"
 msgstr ""
 
-#: data/menu.ui:124 data/menu.ui:333
+#: data/menu.ui:124 data/menu.ui:345
 msgid "Paste As O_verlay…"
 msgstr ""
 
-#: data/menu.ui:119 data/menu.ui:328
+#: data/menu.ui:119 data/menu.ui:340
 msgid "Paste As _Even Pages"
 msgstr ""
 
-#: data/menu.ui:114 data/menu.ui:323
+#: data/menu.ui:114 data/menu.ui:335
 msgid "Paste As _Odd Pages"
 msgstr ""
 
-#: data/menu.ui:129 data/menu.ui:338
+#: data/menu.ui:129 data/menu.ui:350
 msgid "Paste As _Underlay…"
 msgstr ""
 
-#: data/menu.ui:102 data/menu.ui:310
+#: data/menu.ui:102 data/menu.ui:322
 msgid "Paste _After"
 msgstr ""
 
-#: data/menu.ui:109 data/menu.ui:318
+#: data/menu.ui:109 data/menu.ui:330
 msgid "Paste _Before"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1636
+#: pdfarranger/pdfarranger.py:1847
 msgid "Pasted data not valid. Aborting paste."
 msgstr ""
 
-#: data/menu.ui:272
+#: pdfarranger/pageutils.py:162
+msgid "Portrait"
+msgstr ""
+
+#: data/menu.ui:284
 msgid "Pre_ferences"
 msgstr ""
 
-#: pdfarranger/config.py:242
+#: pdfarranger/config.py:235
 msgid "Preferences"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:292
+#: pdfarranger/pdfarranger.py:321
 msgid "Print the version of PDF Arranger and exit"
 msgstr ""
 
-#: pdfarranger/config.py:267
+#: pdfarranger/config.py:260
 msgid "Printing"
 msgstr ""
 
-#: pdfarranger/exporter.py:579
+#: pdfarranger/exporter.py:594
 msgid "Printing…"
 msgstr ""
 
@@ -470,31 +497,35 @@ msgstr ""
 msgid "Property"
 msgstr ""
 
-#: data/menu.ui:182 data/menu.ui:440
+#: pdfarranger/pageutils.py:1060
+msgid "Range Select"
+msgstr ""
+
+#: data/menu.ui:182 data/menu.ui:457
 msgid "Re_verse Order"
 msgstr ""
 
-#: pdfarranger/pageutils.py:250
+#: pdfarranger/pageutils.py:356
 msgid "Relative"
 msgstr ""
 
-#: pdfarranger/exporter.py:617
+#: pdfarranger/exporter.py:632
 msgid "Rendering Preview…"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:746
+#: pdfarranger/pdfarranger.py:955
 msgid "Rendering…"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1146
+#: pdfarranger/pdfarranger.py:1355
 msgid "Replace"
 msgstr ""
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Right"
 msgstr ""
 
-#: pdfarranger/pageutils.py:384
+#: pdfarranger/pageutils.py:480
 msgid "Right to Left"
 msgstr ""
 
@@ -506,15 +537,20 @@ msgstr ""
 msgid "Rotate Right"
 msgstr ""
 
-#: data/menu.ui:152 data/menu.ui:410
+#: data/menu.ui:152 data/menu.ui:427
 msgid "Rotate _Left"
 msgstr ""
 
-#: pdfarranger/pageutils.py:370 pdfarranger/splitter.py:60
+#: pdfarranger/pageutils.py:466 pdfarranger/splitter.py:60
 msgid "Rows"
 msgstr ""
 
-#: data/menu.ui:232 data/menu.ui:396
+#: pdfarranger/pdfarranger.py:3070
+#, python-format
+msgid "Running on %s"
+msgstr ""
+
+#: data/menu.ui:239 data/menu.ui:408
 msgid "Same Page _Format"
 msgstr ""
 
@@ -526,7 +562,7 @@ msgstr ""
 msgid "Save As"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1102
+#: pdfarranger/pdfarranger.py:1311
 msgid "Save As…"
 msgstr ""
 
@@ -534,56 +570,76 @@ msgstr ""
 msgid "Save _As…"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1002
+#: pdfarranger/pdfarranger.py:1212
 msgid "Save changes before closing?"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1039
+#: pdfarranger/pdfarranger.py:1249
 msgid "Save changes before quitting?"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:999
+#: pdfarranger/pdfarranger.py:1209
 msgid "Save changes to “{}” before closing?"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1036
+#: pdfarranger/pdfarranger.py:1246
 msgid "Save changes to “{}” before quitting?"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1257
+#: pdfarranger/pdfarranger.py:1466
 msgid "Saving produced some warnings"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1296
+#: pdfarranger/pdfarranger.py:1505
 msgid "Saving…"
+msgstr ""
+
+#: pdfarranger/pageutils.py:348
+msgid "Scale"
+msgstr ""
+
+#: pdfarranger/pageutils.py:349
+msgid "Scale & Add margins"
 msgstr ""
 
 #: pdfarranger/pageutils.py:121
 msgid "Scale factor"
 msgstr ""
 
-#: pdfarranger/exporter.py:557
+#: pdfarranger/exporter.py:572
 msgid "Scale mode:"
 msgstr ""
 
-#: data/menu.ui:207 data/menu.ui:371
+#: data/menu.ui:214 data/menu.ui:383
 msgid "Select _All"
 msgstr ""
 
-#: data/menu.ui:222 data/menu.ui:386
+#: data/menu.ui:229 data/menu.ui:398
 msgid "Select _Even Pages"
 msgstr ""
 
-#: data/menu.ui:217 data/menu.ui:381
+#: data/menu.ui:224 data/menu.ui:393
 msgid "Select _Odd Pages"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2796
+#: data/menu.ui:249 data/menu.ui:418
+msgid "Select _Range"
+msgstr ""
+
+#: pdfarranger/pageutils.py:1069
+msgid "Select range of pages: "
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3098
 msgid "Selected pages: "
 msgstr ""
 
-#: pdfarranger/pageutils.py:548
+#: pdfarranger/pageutils.py:644
 msgid "Show values"
+msgstr ""
+
+#: data/menu.ui:204 data/menu.ui:479
+msgid "Split (unimposition)"
 msgstr ""
 
 #: pdfarranger/splitter.py:26
@@ -594,28 +650,32 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:523
+#: pdfarranger/pdfarranger.py:704
 msgid "Supported image files"
 msgstr ""
 
-#: pdfarranger/config.py:282 pdfarranger/config.py:290
+#: pdfarranger/config.py:275 pdfarranger/config.py:283
 msgid "System setting"
 msgstr ""
 
-#: pdfarranger/core.py:447
+#: pdfarranger/core.py:446
 msgid ""
 "The document “{}” is locked and requires a password before it can be opened."
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1765
+#: pdfarranger/pdfarranger.py:1976
 msgid "The page has several images. Use \"Explode into Images\" first.\""
 msgstr ""
 
-#: pdfarranger/core.py:446
+#: pdfarranger/pdfarranger.py:558
+msgid "The page selection is not contiguous. Cannot unimpose."
+msgstr ""
+
+#: pdfarranger/core.py:445
 msgid "The password will be remembered until you close PDF Arranger."
 msgstr ""
 
-#: pdfarranger/config.py:260
+#: pdfarranger/config.py:253
 msgid "Theme"
 msgstr ""
 
@@ -623,23 +683,29 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: pdfarranger/pageutils.py:154
+#: pdfarranger/pageutils.py:253
 msgid "Top"
 msgstr ""
 
-#: pdfarranger/pageutils.py:385
+#: pdfarranger/pageutils.py:481
 msgid "Top to Bottom"
 msgstr ""
 
-#: pdfarranger/pageutils.py:899
+#: pdfarranger/pageutils.py:995
 msgid "Underlay"
 msgstr ""
 
-#: pdfarranger/core.py:544 pdfarranger/pdfarranger.py:1502
+#: pdfarranger/core.py:543 pdfarranger/pdfarranger.py:1711
 msgid "Unknown file format"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:2735
+#: pdfarranger/pageutils.py:1076
+msgid ""
+"Use a comma to separate page numbers, a dash to select a range of pages. \n"
+"e.g. : \"1,3,5-7,9\""
+msgstr ""
+
+#: pdfarranger/pdfarranger.py:3035
 msgid "User Manual"
 msgstr ""
 
@@ -647,7 +713,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: pdfarranger/pageutils.py:382
+#: pdfarranger/pageutils.py:478
 msgid "Vertical"
 msgstr ""
 
@@ -655,12 +721,11 @@ msgstr ""
 msgid "Vertical Splits"
 msgstr ""
 
-#: pdfarranger/pageutils.py:454
+#: pdfarranger/pageutils.py:550
 msgid "Vertical offset"
 msgstr ""
 
-#: pdfarranger/pageutils.py:247 pdfarranger/pageutils.py:251
-#: pdfarranger/pageutils.py:333
+#: pdfarranger/pageutils.py:138
 msgid "Width"
 msgstr ""
 
@@ -668,7 +733,7 @@ msgstr ""
 msgid "Width in %"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:983
+#: pdfarranger/pdfarranger.py:1193
 msgid "Your changes will be lost if you don’t save them."
 msgstr ""
 
@@ -680,49 +745,54 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: data/menu.ui:255
+#: data/menu.ui:267
 msgid "Zoom _Fit"
 msgstr ""
 
-#: data/menu.ui:247
+#: data/menu.ui:259
 msgid "Zoom _In"
 msgstr ""
 
-#: data/menu.ui:251
+#: data/menu.ui:263
 msgid "Zoom _Out"
 msgstr ""
 
-#: data/menu.ui:278
+#: data/menu.ui:290
 msgid "_About"
 msgstr ""
 
-#: pdfarranger/pageutils.py:856
+#: pdfarranger/pageutils.py:952
 msgid "_Apply"
 msgstr ""
 
-#: pdfarranger/config.py:246 pdfarranger/pageutils.py:227
-#: pdfarranger/pdfarranger.py:975 pdfarranger/pdfarranger.py:984
-#: pdfarranger/pdfarranger.py:1108 pdfarranger/pdfarranger.py:1158
+#: data/menu.ui:198 data/menu.ui:473
+msgid "_Booklet"
+msgstr ""
+
+#: pdfarranger/config.py:239 pdfarranger/metadata.py:205
+#: pdfarranger/pageutils.py:326 pdfarranger/pdfarranger.py:1185
+#: pdfarranger/pdfarranger.py:1194 pdfarranger/pdfarranger.py:1317
+#: pdfarranger/pdfarranger.py:1367
 msgid "_Cancel"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:994 data/menu.ui:284
+#: pdfarranger/pdfarranger.py:1204 data/menu.ui:296
 msgid "_Close"
 msgstr ""
 
-#: data/menu.ui:98 data/menu.ui:306
+#: data/menu.ui:98 data/menu.ui:318
 msgid "_Copy"
 msgstr ""
 
-#: data/menu.ui:166 data/menu.ui:424
+#: data/menu.ui:166 data/menu.ui:441
 msgid "_Crop Margins…"
 msgstr ""
 
-#: data/menu.ui:90 data/menu.ui:298
+#: data/menu.ui:90 data/menu.ui:310
 msgid "_Delete"
 msgstr ""
 
-#: data/menu.ui:212 data/menu.ui:376
+#: data/menu.ui:219 data/menu.ui:388
 msgid "_Deselect All"
 msgstr ""
 
@@ -730,15 +800,15 @@ msgstr ""
 msgid "_Edit"
 msgstr ""
 
-#: data/menu.ui:137 data/menu.ui:350
+#: data/menu.ui:137 data/menu.ui:362
 msgid "_Explode into Images"
 msgstr ""
 
-#: data/menu.ui:135 data/menu.ui:347
+#: data/menu.ui:135 data/menu.ui:359
 msgid "_Extract"
 msgstr ""
 
-#: data/menu.ui:170 data/menu.ui:428
+#: data/menu.ui:170 data/menu.ui:445
 msgid "_Hide Margins…"
 msgstr ""
 
@@ -746,11 +816,11 @@ msgstr ""
 msgid "_Import"
 msgstr ""
 
-#: data/menu.ui:237 data/menu.ui:401
+#: data/menu.ui:244 data/menu.ui:413
 msgid "_Invert Selection"
 msgstr ""
 
-#: data/menu.ui:190 data/menu.ui:448
+#: data/menu.ui:190 data/menu.ui:465
 msgid "_Merge Pages…"
 msgstr ""
 
@@ -758,15 +828,16 @@ msgstr ""
 msgid "_New Window"
 msgstr ""
 
-#: pdfarranger/config.py:247 pdfarranger/pageutils.py:228
+#: pdfarranger/config.py:240 pdfarranger/metadata.py:206
+#: pdfarranger/pageutils.py:327 pdfarranger/pdfarranger.py:3026
 msgid "_OK"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1157 data/menu.ui:24
+#: pdfarranger/pdfarranger.py:1366 data/menu.ui:24
 msgid "_Open"
 msgstr ""
 
-#: data/menu.ui:162 data/menu.ui:420
+#: data/menu.ui:162 data/menu.ui:437
 msgid "_Page Size…"
 msgstr ""
 
@@ -774,7 +845,7 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:1031 data/menu.ui:290
+#: pdfarranger/pdfarranger.py:1241 data/menu.ui:302
 msgid "_Quit"
 msgstr ""
 
@@ -782,24 +853,24 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-#: pdfarranger/pageutils.py:856
+#: pdfarranger/pageutils.py:952
 msgid "_Revert"
 msgstr ""
 
-#: data/menu.ui:157 data/menu.ui:415
+#: data/menu.ui:157 data/menu.ui:432
 msgid "_Rotate Right"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:984 pdfarranger/pdfarranger.py:1107
+#: pdfarranger/pdfarranger.py:1194 pdfarranger/pdfarranger.py:1316
 #: data/menu.ui:42
 msgid "_Save"
 msgstr ""
 
-#: data/menu.ui:204 data/menu.ui:368
+#: data/menu.ui:211 data/menu.ui:380
 msgid "_Select"
 msgstr ""
 
-#: data/menu.ui:186 data/menu.ui:444
+#: data/menu.ui:186 data/menu.ui:461
 msgid "_Split Pages…"
 msgstr ""
 
@@ -807,19 +878,19 @@ msgstr ""
 msgid "_Undo"
 msgstr ""
 
-#: data/menu.ui:244
+#: data/menu.ui:256
 msgid "_View"
 msgstr ""
 
-#: pdfarranger/pageutils.py:144 pdfarranger/pageutils.py:368
-#: pdfarranger/pageutils.py:418
+#: pdfarranger/pageutils.py:142 pdfarranger/pageutils.py:148
+#: pdfarranger/pageutils.py:464 pdfarranger/pageutils.py:514
 msgid "mm"
 msgstr ""
 
-#: pdfarranger/core.py:326
+#: pdfarranger/core.py:695
 msgid "page"
 msgstr ""
 
-#: pdfarranger/pdfarranger.py:825
+#: pdfarranger/pdfarranger.py:1035
 msgid "untitled"
 msgstr ""

--- a/tests/test.py
+++ b/tests/test.py
@@ -704,7 +704,7 @@ class TestBatch5(PdfArrangerTest):
 
     def test_03_booklet(self):
         self._popupmenu(0, ["Select", "Select All"])
-        self._popupmenu(0, ["Generate Booklet"])
+        self._popupmenu(0, ["Booklet", "Generate (imposition)"])
         self._wait_cond(lambda: len(self._icons()) == 2)
         self._app().child(roleName="layered pane").keyCombo("Home")
         self._assert_page_size(491.1, 213.3)
@@ -720,16 +720,31 @@ class TestBatch5(PdfArrangerTest):
         self._assert_page_size(245.2, 213.3, 0)
         self._assert_page_size(245.2, 213.3, 1)
 
-    def test_05_buggy_exif(self):
+    def test_05_split_booklet(self):
+        self._popupmenu(0, ["Select", "Select All"])
+        self._popupmenu(0, ["Booklet", "Generate (imposition)"])
+        self._popupmenu(0, ["Select", "Select All"])
+        self._popupmenu(0, ["Booklet", "Split (unimposition)"])
+        # OK OK hear me out generating the booklet took 2 pages and made it 2 after the process
+        # by adding two blank pages at the end. So we should have 4 now.
+        # They should have 245.2x213.3mm size like in test_04 because
+        # test.pdf is only loaded once for all operations.
+        self._wait_cond(lambda: len(self._icons()) == 4)
+        self._app().child(roleName="layered pane").keyCombo("Home")
+        self._assert_page_size(245.2, 213.3)
+        self._app().child(roleName="layered pane").keyCombo("End")
+        self._assert_page_size(245.2, 213.3)
+
+    def test_06_buggy_exif(self):
         """Test img2pdf import with buggy EXIF rotation"""
         if not check_img2pdf([0,4,2]):
             print("Ignoring test_05_buggy_exif, img2pdf too old")
             return
         filechooser = self._import_file("tests/1x1.jpg")
         self._wait_cond(lambda: filechooser.dead)
-        self.assertEqual(len(self._icons()), 3)
+        self.assertEqual(len(self._icons()), 5)
 
-    def test_06_quit(self):
+    def test_07_quit(self):
         self._quit_without_saving()
 
 


### PR DESCRIPTION
This is a much requested feature by my friends who make zines, and was also requested in #1067. This is the only feature from booklet-imposer missing in pdfarranger (booklet-imposer is deprecated).

This PR adds an unimposition checkbox in the split pages menu.

TODO:

- [x] work on page selection, not just entire document
- [x] make sure page selection is contiguous
- [x] update translations
- [ ] tests pass

I wanted to have feedback to help finalize this PR so i'm posting early. Here's a preview:

![unimpose](https://github.com/user-attachments/assets/0edec8eb-427c-41b8-a6eb-06ccebbd07fa)


