### PR TITLE
Allow single lang updatepo.sh, and update translation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,32 +94,27 @@ python3 -m pdfarranger
 
 ## For translators
 
+Translations are located in the following files:
+
+*   [`po`](po)`/LANG.po` for interface translation strings
+*   [data/com.github.jeromerobert.pdfarranger.metainfo.xml](data/com.github.jeromerobert.pdfarranger.metainfo.xml) for repository integration
+*   [data/com.github.jeromerobert.pdfarranger.desktop](data/com.github.jeromerobert.pdfarranger.desktop) for desktop integration
+
+If you are not comfortable working with git, **you may edit translations directly from Github's web interface**. However, in the normal case
+you would contribute translations by following these steps:
+
 *   Download the main branch (see [For developers](#for-developers))
+*   Checkout a new branch to save your changes: `git checkout -b update-translation-LANG`
+*   Run `po/updatepo.sh LANG`, where `LANG` is the locale you'd like to update
+*   Update your translations in `po/LANG.po` file, and commit them; do not commit changes to `po/pdfarranger.pot` which may have been
+    automatically regenerated
+*   If possible, test your translation to see it in context (see [For developers](#for-developers))
+*   Create a new pull request with your changes to the main branch
 
-*   Run `po/genpot.sh`. The `pot` is an automatically generated file and as such
-    should not be in the repository. It is to make life of some translators
-    easier, but it might be out of sync with the source code. If you can
-    regenerate it before adding or updating a translation, then do it.
+If you are editing mnemonics accelerators (letters preceded by an underscore), here are some additional guidelines. However, if you have no idea what this means, don't worry about it.
+Try to follow these rules by priority order:
 
-*   Translations are in the following files:
-    *   [`po`](po)`/*.po`
-    *   [data/com.github.jeromerobert.pdfarranger.metainfo.xml](data/com.github.jeromerobert.pdfarranger.metainfo.xml)
-    *   [data/com.github.jeromerobert.pdfarranger.desktop](data/com.github.jeromerobert.pdfarranger.desktop)
-
-*   For mnemonics accelerators (letters preceded by an underscore) try to follow
-    those rules by priority order:
-    *   be consistent with other GTK/GNOME software
-    *   pick a unique letter **within that given menu** if possible
-    *   pick the same letter as the original string if available
-    *   pick a strong letter (e.g. in "Search and replace" rather pick `s`, `r` or `p` than `a`)
-
-*   If possible, test your translation to see it in context
-    (see [For developers](#for-developers))
-
-*   Do not include `pdfarranger.pot` (or any `*.po` file which was just
-    automatically regenerated) in your pull request. Submit only the translations
-    you actually updated or added.
-
-*   If you don’t want or can’t use the developers tooling (`git`,
-    `po/genpot.sh`, `python`, …) you can edit, download or upload the `*.po`
-    files from the GitHub web pages.
+*   be consistent with other GTK/GNOME software
+*   pick a unique letter **within that given menu** if possible
+*   pick the same letter as the original string if available
+*   pick a strong letter (e.g. in "Search and replace" rather pick `s`, `r` or `p` than `a`)

--- a/po/updatepo.sh
+++ b/po/updatepo.sh
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+# Update translation files, after updating pdfarranger.pot
+#   - all translation files if no argument is passed
+#   - $1.po if an argument is passed (for example `updatepo.sh fr` for french locale)
 
 #
 # pdfarranger - GTK+ based utility for splitting, rearrangement and
@@ -20,10 +24,35 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-# Update translation files
 cd "$(dirname "$0")/.."
-for po in po/*.po
-do
-  msgmerge --backup none -U "$po" po/pdfarranger.pot
-  msgattrib --no-obsolete --clear-fuzzy --empty -o "$po" "$po"
-done
+
+updatepo() {
+  msgmerge --backup none -U "$1" po/pdfarranger.pot
+  msgattrib --no-obsolete --clear-fuzzy --empty -o "$1" "$1"
+}
+
+# Make sure pdfarranger.pot is up-to-date
+po/genpot.sh
+
+if [[ "$1" = "" ]]; then
+  for po in po/*.po
+  do
+    updatepo "$po"
+  done
+else
+  if [ -f "po/$1.po" ]; then
+    updatepo "po/$1.po"
+  else
+    echo "No such translation locale: $1."
+    read -r -p "Would you like to create new translation locale $1? [y/N] " response
+    case "$response" in
+      [yY][eE][sS]|[yY]) 
+        cp po/pdfarranger.pot "po/$1.po"
+        ;;
+      *)
+        echo "Unknown translation: $1"
+        exit 1
+        ;;
+    esac
+  fi
+fi


### PR DESCRIPTION
The translation docs were not really clear: it was just a bunch of lists with a lot of sub-items, and never mentioned "updatepo.sh". I tried to improve on this.

Also i allowed updatepo.sh to regenerate the po file for a single language (so you don't pollute the git working dir with useless files), and to create the translation file for a new language... is copying pdfarranger.pot the actual good way to do this?

We could also add documentation about how to add a new language eventually.