### PR TITLE
Retain XMP metadata when saving

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -140,6 +140,13 @@ class DogtailManager:
 # dogtail does not support change of X11 server so it must be a singleton
 dogtail_manager = DogtailManager()
 
+def setUpModule():
+    # if we can't kill the dbus process on GHA, let's at least suppress the warning
+    if dogtail_manager.xvfb and "GITHUB_ACTIONS" in os.environ:
+        warnings.filterwarnings("ignore",
+                                f"subprocess {dogtail_manager.xvfb.dbus_proc.pid} is still running",
+                                ResourceWarning)
+
 def tearDownModule():
     dogtail_manager.kill()
 

--- a/tests/test_metadata1.pdf
+++ b/tests/test_metadata1.pdf
@@ -7,12 +7,12 @@ endobj
 << /Author (First) /Custom (info dict entry) /Title (Title1) >>
 endobj
 3 0 obj
-<< /Subtype /XML /Type /Metadata /Length 403 >>
+<< /Subtype /XML /Type /Metadata /Length 589 >>
 stream
 <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="pikepdf">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
- <rdf:Description rdf:about=""><dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/"><rdf:Seq><rdf:li>First</rdf:li><rdf:li>Second</rdf:li></rdf:Seq></dc:creator></rdf:Description></rdf:RDF>
+ <rdf:Description rdf:about=""><dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/"><rdf:Seq><rdf:li>First</rdf:li><rdf:li>Second</rdf:li></rdf:Seq></dc:creator></rdf:Description><rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="" dc:identifier="ID1"/><rdf:Description xmlns:xmp="http://ns.adobe.com/xap/1.0/" rdf:about="" xmp:label="Label1"/></rdf:RDF>
 </x:xmpmeta>
 
 <?xpacket end="w"?>
@@ -37,10 +37,10 @@ xref
 0000000015 00000 n 
 0000000080 00000 n 
 0000000159 00000 n 
-0000000643 00000 n 
-0000000702 00000 n 
-0000000808 00000 n 
-trailer << /Info 2 0 R /Root 1 0 R /Size 7 /ID [<7a82e63020abaefab2663adc0e870ef1><7a82e63020abaefab2663adc0e870ef1>] >>
+0000000829 00000 n 
+0000000888 00000 n 
+0000000994 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 7 /ID [<ba94ae4e90d75331b5acf31c0b9aefc3><ba94ae4e90d75331b5acf31c0b9aefc3>] >>
 startxref
-857
+1043
 %%EOF

--- a/tests/test_metadata2.pdf
+++ b/tests/test_metadata2.pdf
@@ -1,0 +1,46 @@
+%PDF-1.3
+%¿÷¢þ
+1 0 obj
+<< /Metadata 3 0 R /Pages 4 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Subject (Subject2) /Title (Title2) >>
+endobj
+3 0 obj
+<< /Subtype /XML /Type /Metadata /Length 408 >>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="pikepdf">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="" dc:source="Source2"/><rdf:Description xmlns:xmp="http://ns.adobe.com/xap/1.0/" rdf:about="" xmp:label="Label2"/></rdf:RDF>
+</x:xmpmeta>
+
+<?xpacket end="w"?>
+
+endstream
+endobj
+4 0 obj
+<< /Count 1 /Kids [ 5 0 R ] /Type /Pages >>
+endobj
+5 0 obj
+<< /Contents 6 0 R /MediaBox [ 0 0 612 792 ] /Parent 4 0 R /Resources << >> /Type /Page >>
+endobj
+6 0 obj
+<< /Length 0 >>
+stream
+
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000626 00000 n 
+0000000685 00000 n 
+0000000791 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 7 /ID [<2a944747abe60ca2c2a842389fc162ba><2a944747abe60ca2c2a842389fc162ba>] >>
+startxref
+840
+%%EOF


### PR DESCRIPTION
XMP metadata should not be overwritten by their corresponding docinfo entries.

Fixes #1168