### PR TITLE
TST: Improve dogtail tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -163,6 +163,7 @@ class PdfArrangerManager:
         return self.process.stdout.read().decode("utf-8")
 
     def kill(self):
+        self.process.stdout.close()
         self.process.kill()
         self.process.wait()
 
@@ -366,15 +367,11 @@ class PdfArrangerTest(unittest.TestCase):
     def _zoom(widget, n_events, zoom_in):
         """Zoom in/out with ctrl + mouse scroll wheel"""
         from dogtail import rawinput
-        from pyatspi import Registry as registry
-        from pyatspi import KEY_PRESS, KEY_RELEASE
-        code = rawinput.keyNameToKeyCode("Control_L")
-        registry.generateKeyboardEvent(code, None, KEY_PRESS)
-        button = 4 if zoom_in == True else 5
+        button = 4 if zoom_in else 5
+        rawinput.holdKey("Control_L")
         for __ in range(n_events):
             widget.click(button=button)
-            time.sleep(0.1)
-        registry.generateKeyboardEvent(code, None, KEY_RELEASE)
+        rawinput.releaseKey("Control_L")
 
     def _quit(self):
         self._app().child(roleName="layered pane").keyCombo("<ctrl>q")
@@ -437,13 +434,10 @@ class TestBatch1(PdfArrangerTest):
     def test_01_import_img(self):
         self._start(["data/screenshot.png"])
         # Handle the "content loss warning" dialog
-        self._wait_cond(lambda: len(self._find_by_role("dialog")) > 0)
         dialog = self._find_by_role("dialog")[-1]
-        self._wait_cond(lambda: len(self._find_by_role("check box", dialog)) > 0)
         check_box = self._find_by_role("check box", dialog)[-1]
         check_box.click()  # Don't show this dialog again
-        button = self._find_by_role("push button", dialog)[-1]
-        button.click()
+        dialog.button("OK").click()
         self._wait_cond(lambda: dialog.dead)
 
     def test_02_properties(self):
@@ -471,8 +465,8 @@ class TestBatch1(PdfArrangerTest):
 
     def test_03_zoom(self):
         app = self._app()
-        zoomoutb = app.child(roleName="push button", description="Zoom Out")
-        zoominb = app.child(roleName="push button", description="Zoom In")
+        zoomoutb = app.child(description="Zoom Out")
+        zoominb = app.child(description="Zoom In")
         # maximum dezoom whatever the initial zoom level
         for _ in range(10):
             zoomoutb.click()


### PR DESCRIPTION
- do not explicitly use `"push button"` role as it was renamed to `"button"` in at-spi2-core 2.53.1 (see [this commit](https://gitlab.gnome.org/GNOME/at-spi2-core/-/commit/0c2ebfad9ebf92913a326143345b841d54fa1866))
- prevent `ResourceWarning: unclosed file <_io.BufferedReader name=...>`
- simplify a bit by using dogtail's built-in methods `holdKey`, `releaseKey` and `widget.button()`