### PR TITLE
fix #1200: save to original iff it's the only one in queue

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1440,8 +1440,12 @@ class PdfArranger(Gtk.Application):
         """Saves to the previously exported file or shows the export dialog if
         there was none."""
         savemode = 'ALL_TO_SINGLE'
+        """Saves to the previously exported file, the original file, or shows the export dialog if
+        there was neither."""
         if self.save_file:
             self.save(savemode, [self.save_file])
+        elif len(self.pdfqueue) == 1:
+            self.save(savemode, [self.pdfqueue[0].filename])
         else:
             self.choose_export_pdf_name(savemode)
 


### PR DESCRIPTION
Modify the behavior of "Save" to match typical meaning of that action; specifically, overwrite the file if only one was opened. In detail:
As before, continue to use the previously saved filename. However, if this is the first save (and save_file is empty), then inspect the pdfqueue.  If there is only one file open, then use that filename.  Otherwise, as before, display the filename chooser.