### PR TITLE
fix #1202: Make optional the saving of window geom on exit

### DIFF
--- a/pdfarranger/config.py
+++ b/pdfarranger/config.py
@@ -117,6 +117,9 @@ class Config(object):
         self.data.read(Config._config_file(domain))
         if 'preferences' not in self.data:
             self.data.add_section('preferences')
+        preferences = self.data['preferences']
+        if 'save-window-geometry' not in preferences:
+            preferences['save-window-geometry'] = 'true'
         if 'print-settings' not in self.data:
             self.data.add_section('print-settings')
         if 'image-export' not in self.data:
@@ -141,6 +144,9 @@ class Config(object):
             if keyevent.state & mods == mods and keyevent.keyval == key:
                 return True
         return False
+
+    def save_window_geometry(self):
+        return self.data.getboolean('preferences', 'save-window-geometry', fallback=True)
 
     def window_size(self):
         ds = Gdk.Screen.get_default()

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1440,8 +1440,12 @@ class PdfArranger(Gtk.Application):
         """Saves to the previously exported file or shows the export dialog if
         there was none."""
         savemode = 'ALL_TO_SINGLE'
+        """Saves to the previously exported file, the original file, or shows the export dialog if
+        there was neither."""
         if self.save_file:
             self.save(savemode, [self.save_file])
+        elif len(self.pdfqueue) == 1:
+            self.save(savemode, [self.pdfqueue[0].filename])
         else:
             self.choose_export_pdf_name(savemode)
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1276,9 +1276,10 @@ class PdfArranger(Gtk.Application):
         # Release Poppler.Document instances to unlock all temporary files
         self.pdfqueue = []
         gc.collect()
-        self.config.set_window_size(self.window.get_size())
-        self.config.set_maximized(self.window.is_maximized())
-        self.config.set_zoom_level(round(self.zoom_level))
+        if self.config.save_window_geometry():
+            self.config.set_window_size(self.window.get_size())
+            self.config.set_maximized(self.window.is_maximized())
+            self.config.set_zoom_level(round(self.zoom_level))
         self.config.save()
         if os.path.isdir(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)


### PR DESCRIPTION
Introduce a config option "save-window-geometry", which defaults to
"true", and controls whether transient window properties will be written
to the config file upon exit.

By setting the option to "false" in the config file, transient window
properties will not be saved, and the config file will be modified only
if there are other (more important) preference changes.
