### PR TITLE
ignore pdfarranger.egg-info in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 venv/
 tests/exporter/out.pdf
 build/
+pdfarranger.egg-info/


### PR DESCRIPTION
The egg-info directory is not source code.  It is the product of building using pip[3x].