### PR TITLE
change wrong package name syntax

### DIFF
--- a/Win32.md
+++ b/Win32.md
@@ -23,7 +23,7 @@ pacman -S mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python-gobject \
  mingw-w64-x86_64-python-lxml mingw-w64-x86_64-qpdf mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext mingw-w64-x86_64-gnutls mingw-w64-x86_64-python-pillow \
  mingw-w64-x86_64-python-dateutil mingw-w64-x86_64-python-pip mingw-w64-x86_64-libhandy \
- mingw-w64-x86_64-python-cx_Freeze git python-pip
+ mingw-w64-x86_64-python-cx-freeze git python-pip
 ```
 
 For Python 3.12 or newer:


### PR DESCRIPTION
I also need to ran these two commands before building the app for it to not spew out errors
export XDG_DATA_DIRS=/mingw64/share:$XDG_DATA_DIRS 
export GIO_MODULE_DIR=/mingw64/lib/gio/modules