### PR TITLE
Map MIME type image/jp2 to extension .jp2

### DIFF
--- a/pdfarranger/core.py
+++ b/pdfarranger/core.py
@@ -562,6 +562,8 @@ class PDFDoc:
             self.basename = description.split('\n')[0]
         self.blank_size = blank_size  # != None if page is blank
         self.password = ""
+        # MIME type for jp2 missing in python prior 3.14.0
+        mimetypes.add_type('image/jp2', '.jp2', strict=True)
         filemime = mimetypes.guess_type(self.filename, strict=False)[0]
         if not filemime:
             raise PDFDocError(_("Unknown file format") + ": " + filename)


### PR DESCRIPTION
jp2 mimetype added to cpython Nov 18, 2024. I'm not sure in which python version it is available. At least on python 3.13.5 it works fine.