### PR TITLE
Fix false "unsaved" state on accidental micro-drag

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -2234,6 +2234,13 @@ class PdfArranger(Gtk.Application):
         target = selection_data.get_target().name()
         if target == 'MODEL_ROW_INTERN':
             move = context.get_selected_action() & Gdk.DragAction.MOVE
+            if move and ref_to:
+                indices = sorted(int(p) for p in data)
+                target_idx = ref_to.get_path().get_indices()[0]
+                insert_pos = target_idx if before else target_idx + 1
+                continuous = len(indices) == indices[-1] - indices[0] + 1
+                if continuous and indices[0] <= insert_pos <= indices[-1] + 1:
+                    return
             self.undomanager.commit("Move" if move else "Copy")
             self.set_unsaved(True)
             data.sort(key=int, reverse=not before)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -2214,6 +2214,15 @@ class PdfArranger(Gtk.Application):
             return
         selection_data.set(selection_data.get_target(), 8, data.encode())
 
+    @staticmethod
+    def _is_noop_move(data, ref_to, before):
+        """Check if a move would not change page order."""
+        indices = sorted(int(p) for p in data)
+        target_idx = ref_to.get_path().get_indices()[0]
+        insert_pos = target_idx if before else target_idx + 1
+        continuous = len(indices) == indices[-1] - indices[0] + 1
+        return continuous and indices[0] <= insert_pos <= indices[-1] + 1
+
     def iv_dnd_received_data(self, iconview, context, _x, _y,
                              selection_data, _target_id, etime):
         """Handles received data by drag and drop in iconview"""
@@ -2234,13 +2243,8 @@ class PdfArranger(Gtk.Application):
         target = selection_data.get_target().name()
         if target == 'MODEL_ROW_INTERN':
             move = context.get_selected_action() & Gdk.DragAction.MOVE
-            if move and ref_to:
-                indices = sorted(int(p) for p in data)
-                target_idx = ref_to.get_path().get_indices()[0]
-                insert_pos = target_idx if before else target_idx + 1
-                continuous = len(indices) == indices[-1] - indices[0] + 1
-                if continuous and indices[0] <= insert_pos <= indices[-1] + 1:
-                    return
+            if move and ref_to and self._is_noop_move(data, ref_to, before):
+                return
             self.undomanager.commit("Move" if move else "Copy")
             self.set_unsaved(True)
             data.sort(key=int, reverse=not before)


### PR DESCRIPTION
Fixes #1363

When an internal drag-and-drop gesture completed without actually reordering pages (e.g. a micro-drag caused by motor impairment or hand tremor), `set_unsaved(True)` was called unconditionally, before checking whether the page order had changed at all.

This fix captures the page order before and after the DnD operation and only commits to the undo history and marks the document as unsaved if the order actually changed.