### PR TITLE
Rebuild PDF outlines on export (single-file, export_doc path only)

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Upgrade pip
       run: pip install --upgrade pip
     - name: Install
-      run: pip3 install -v --upgrade .[image] coverage
+      run: pip3 install -v --upgrade .[image] coverage pytest
     - name: AppStream
       run: appstreamcli validate $HOME/.local/share/metainfo/com.github.jeromerobert.pdfarranger.metainfo.xml
     - name: Validate Desktop File
@@ -25,9 +25,11 @@ jobs:
       run: python3 -X tracemalloc -u -m unittest -v -f tests.test
     - name: Exporter Tests and Coverage
       run: python3 -m coverage run --data-file=.coverage.exporter -m unittest -v -f tests.test_exporter
+    - name: Exporter Outlines Tests and Coverage
+      run: python3 -m coverage run --data-file=.coverage.exporter_outlines -m pytest -v tests/test_exporter_outlines.py
     - name: Core Tests and Coverage
       run: python3 -m coverage run --data-file=.coverage.core -m unittest -v -f tests.test_core
-    # Convert to lcov because it's compatible with codecov AND can be combine
+    # Convert to lcov because it's compatible with codecov AND can be combined
     - name: Convert to lcov
       run: python3 -m coverage combine && python3 -m coverage lcov
     # Upload for later use (see upload-to-codecov job)
@@ -44,11 +46,13 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install
-      run: pip3 install -v .[image]
+      run: pip3 install -v .[image] coverage && pip3 install -v --ignore-installed pytest
     - name: Dogtail Tests and Coverage
       run: python3 -X tracemalloc -u -m unittest -v -f tests.test
     - name: Exporter Tests and Coverage
       run: python3 -m coverage run --data-file=.coverage.exporter -m unittest -v -f tests.test_exporter
+    - name: Exporter Outlines Tests and Coverage
+      run: python3 -m coverage run --data-file=.coverage.exporter_outlines -m pytest -v tests/test_exporter_outlines.py
     - name: Core Tests and Coverage
       run: python3 -m coverage run --data-file=.coverage.core -m unittest -v -f tests.test_core
     - name: Convert to lcov

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -49,3 +49,5 @@ jobs:
         run: python3 -X tracemalloc -u -m unittest -v -f tests.test
       - name: Exporter Tests
         run: python3 -X tracemalloc -u -m unittest -v -f tests.test_exporter
+      - name: Exporter Outlines Tests
+        run: python3 -X tracemalloc -u -m unittest -v -f tests.test_exporter_outlines

--- a/pdfarranger/config.py
+++ b/pdfarranger/config.py
@@ -351,8 +351,12 @@ class Config(object):
         if self.has_pikepdf8:
             frame4 = Gtk.Frame(label=_("Saving/exporting to single file"), margin=8)
             cb_retain = Gtk.CheckButton(
-                label=_("Retain document-level information of the first opened file"),
+                label=_("Preserve document information from the first file opened"),
                 margin=8)
+            cb_retain.set_tooltip_text("\n".join([
+                _("When checked: use document properties from the first file opened."),
+                _("When unchecked: merge bookmarks from all documents.")
+            ]))
             cb_retain.set_active(not self.start_with_empty())
             frame4.add(cb_retain)
             d.vbox.pack_start(frame4, False, False, 8)

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -400,6 +400,10 @@ def export_doc(pdf_input, pages, mdata, files_out, quit_flag, test_mode=False):
         return
     if isinstance(files_out[0], str):
         # Only needed when saving to file, not when printing
+        if len(files_out) == 1:
+            # Imported here to avoid circular import with exporter_outlines
+            from . import exporter_outlines
+            exporter_outlines.rebuild_outlines(pdf_input, pdf_output, pages)
         mdata = metadata.merge_doc(mdata, pdf_input)
     if len(files_out) > 1:
         for n, page in enumerate(pdf_output.pages):

--- a/pdfarranger/exporter_outlines.py
+++ b/pdfarranger/exporter_outlines.py
@@ -1,0 +1,212 @@
+# pdfarranger is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Rebuild PDF outlines after page reorder, subset, or merge."""
+
+import warnings
+import pikepdf
+import decimal
+
+
+class OutlineRemapper:
+    """
+    Maps source-file bookmark destinations to their new locations in the output PDF.
+
+    Constructed once per export with the full list of input PDFs and the output
+    page sequence. Internally builds:
+      - a reverse map from each source page's object identity to its source index
+      - a forward map from (file_idx, source_page_idx, copy_number) to output page index
+      - a cache of named destinations per source file
+
+    When a source page appears multiple times in the output, bookmarks always
+    resolve to the first copy (copy_number=0). Subsequent copies are not bookmarked.
+    """
+
+    def __init__(self, pdf_input, pdf_output, pages):
+        """Build page index maps and destination caches from the input PDFs."""
+        self.pdf_input = pdf_input
+        self.pdf_output = pdf_output
+        self.pages = pages  # Store pages to access geometry/scale later
+        self.rev_maps = {}
+        self.dest_caches = {}
+        self.new_named_dests = []
+        self.page_index_map = {}
+        instance_counts = {}
+        for out_idx, row in enumerate(pages):
+            file_idx = row.nfile - 1
+            src_page_idx = row.npage - 1
+            key = (file_idx, src_page_idx)
+            inst_num = instance_counts.get(key, 0)
+            # Map (file_idx, source_page_idx, instance_num) -> output_page_index
+            self.page_index_map[(key[0], key[1], inst_num)] = out_idx
+            instance_counts[key] = inst_num + 1
+        for file_idx, pdf in enumerate(pdf_input):
+            if pdf is None:
+                continue
+            self.rev_maps[file_idx] = {p.obj.objgen: i for i, p in enumerate(pdf.pages)}
+            dests = {}
+            if pikepdf.Name.Dests in pdf.Root:
+                for k, v in pdf.Root.Dests.items():
+                    dests[str(k).lstrip("/")] = v
+            if pikepdf.Name.Names in pdf.Root and pikepdf.Name.Dests in pdf.Root.Names:
+                dests.update(dict(pikepdf.NameTree(pdf.Root.Names.Dests).items()))
+            self.dest_caches[file_idx] = dests
+
+    def remap_destination(self, file_idx, dest):
+        """Remap a bookmark destination to its new location and scale coordinates."""
+        original_name = None
+        if isinstance(dest, (pikepdf.String, pikepdf.Name)):
+            original_name = str(dest).lstrip("/")
+            dest_obj = self.dest_caches[file_idx].get(original_name)
+            if not dest_obj:
+                return None
+            try:
+                dest_array = dest_obj.D
+            except (AttributeError, ValueError):
+                dest_array = dest_obj
+        else:
+            dest_array = dest
+        if not isinstance(dest_array, pikepdf.Array) or len(dest_array) < 2:
+            return None
+        target_ref = dest_array[0]
+        if not hasattr(target_ref, "objgen"):
+            return None
+        source_page_idx = self.rev_maps[file_idx].get(target_ref.objgen)
+        if source_page_idx is None:
+            return None
+        # Target first copy (0) of each page. Other copies are not bookmarked.
+        target_out_idx = self.page_index_map.get((file_idx, source_page_idx, 0))
+        if target_out_idx is None:
+            return None
+        # Grab scale from the Row object to transform the bookmark coordinates
+        target_page_obj = self.pdf_output.pages[target_out_idx].obj
+        row = self.pages[target_out_idx]
+        scale = getattr(row, "scale", 1.0)
+        return self._new_dest_array(
+            dest_array, target_page_obj, file_idx, scale, original_name
+        )
+
+    def _new_dest_array(
+        self, dest_array, target_page_obj, file_idx, scale, original_name
+    ):
+        new_dest_array = pikepdf.Array()
+        new_dest_array.append(target_page_obj)
+        d_type = dest_array[1]
+        new_dest_array.append(d_type)
+        # Identify coordinate parameters based on destination type
+        coord_indices = []
+        if d_type == pikepdf.Name.XYZ:
+            coord_indices = [2, 3]  # left, top (zoom ratio at index 4 is not scaled)
+        elif d_type in (
+            pikepdf.Name.FitH,
+            pikepdf.Name.FitBH,
+            pikepdf.Name.FitV,
+            pikepdf.Name.FitBV,
+        ):
+            coord_indices = [2]  # [top] or [left]
+        elif d_type == pikepdf.Name.FitR:
+            coord_indices = [2, 3, 4, 5]  # [left, bottom, right, top]
+        # Apply scale directly to coordinates
+        for i in range(2, len(dest_array)):
+            val = dest_array[i]
+            if i in coord_indices and isinstance(val, (int, float, decimal.Decimal)):
+                new_dest_array.append(float(val) * scale)
+            elif isinstance(val, pikepdf.Object) and val.is_indirect:
+                new_dest_array.append(self.pdf_output.copy_foreign(val))
+            else:
+                new_dest_array.append(val)
+        if original_name:
+            new_name_str = f"f{file_idx}-{original_name}"
+            self.new_named_dests.append((new_name_str, new_dest_array))
+            return pikepdf.String(new_name_str)
+        return new_dest_array
+
+
+class OutlineCopier:
+    """Copy outline items from a source PDF, remapping destinations."""
+
+    def __init__(self, remapper, file_idx):
+        """Initialize with a remapper and the source file index."""
+        self.remapper = remapper
+        self.file_idx = file_idx
+
+    def _get_mapped_dest(self, source_item):
+        """Extract and remap the destination from a source outline item."""
+        dest = source_item.destination
+        if dest is None and source_item.action:
+            if source_item.action.get(pikepdf.Name.S) == pikepdf.Name.GoTo:
+                dest = source_item.action.get(pikepdf.Name.D)
+        if dest is not None:
+            return self.remapper.remap_destination(self.file_idx, dest)
+        return None
+
+    def _copy_styles_and_state(self, source_item, new_item):
+        """Preserve color, text style flags, and default open/closed state."""
+        if source_item.is_closed:
+            new_item.is_closed = True
+        for key in (pikepdf.Name.C, pikepdf.Name.F):
+            if key in source_item.obj:
+                if new_item.obj is None:
+                    new_item.obj = pikepdf.Dictionary()
+                new_item.obj[key] = source_item.obj[key]
+
+    def copy_item(self, source_item, new_parent_list):
+        """Copy a single outline item and its children, dropping invalid destinations."""
+        final_dest = self._get_mapped_dest(source_item)
+        new_item = pikepdf.OutlineItem(title=source_item.title, destination=final_dest)
+        # Recursively process children first so we know if new_item has valid children
+        for child in source_item.children:
+            self.copy_item(child, new_item.children)
+        # Only copy bookmark if it has a valid destination or valid surviving children
+        if final_dest is not None or new_item.children:
+            self._copy_styles_and_state(source_item, new_item)
+            new_parent_list.append(new_item)
+
+
+def write_named_dests(pdf, named_dests):
+    """Write a list of (name, dest_array) pairs into the PDF's name tree."""
+    if not named_dests:
+        return
+    if pikepdf.Name.Names not in pdf.Root:
+        pdf.Root.Names = pdf.make_indirect(pikepdf.Dictionary())
+    if pikepdf.Name.Dests in pdf.Root.Names:
+        nt = pikepdf.NameTree(pdf.Root.Names.Dests)
+    else:
+        nt = pikepdf.NameTree.new(pdf)
+        pdf.Root.Names.Dests = nt.obj
+    for name_str, dest_array in named_dests:
+        nt[name_str] = dest_array
+
+
+def rebuild_outlines(pdf_input, pdf_output, pages):
+    """Rebuild outlines in pdf_output by remapping bookmarks from pdf_input."""
+    remapper = OutlineRemapper(pdf_input, pdf_output, pages)
+    # preserve first-appearance order of source files, deduplicated
+    ordered_file_indices = list(dict.fromkeys(row.nfile - 1 for row in pages))
+    with pdf_output.open_outline() as new_outline:
+        for file_idx in ordered_file_indices:
+            source_pdf = pdf_input[file_idx]
+            if source_pdf is None or pikepdf.Name.Outlines not in source_pdf.Root:
+                continue
+            try:
+                with source_pdf.open_outline() as source_outline:
+                    copier = OutlineCopier(remapper, file_idx)
+                    for item in source_outline.root:
+                        copier.copy_item(item, new_outline.root)
+            except pikepdf.PdfError as e:
+                warnings.warn(
+                    f"Failed to copy bookmarks from document {file_idx + 1}: {e}"
+                )
+    if remapper.new_named_dests:
+        write_named_dests(pdf_output, remapper.new_named_dests)

--- a/tests/exporter/test19_out.pdf
+++ b/tests/exporter/test19_out.pdf
@@ -5,31 +5,76 @@
 %% Original object ID: 1 0
 1 0 obj
 <<
-  /Pages 2 0 R
+  /Outlines 2 0 R
+  /Pages 3 0 R
   /Type /Catalog
 >>
 endobj
 
-%% Original object ID: 2 0
+%% Original object ID: 74 0
 2 0 obj
 <<
   /Count 4
+  /First 4 0 R
+  /Last 5 0 R
+  /Type /Outlines
+>>
+endobj
+
+%% Original object ID: 2 0
+3 0 obj
+<<
+  /Count 4
   /Kids [
-    3 0 R
-    4 0 R
-    5 0 R
     6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
   ]
   /Type /Pages
 >>
 endobj
 
+%% Original object ID: 75 0
+4 0 obj
+<<
+  /Count 0
+  /Dest [
+    6 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 10 0 R
+  /Parent 2 0 R
+  /Title (Page 1)
+>>
+endobj
+
+%% Original object ID: 78 0
+5 0 obj
+<<
+  /Count 0
+  /Dest [
+    9 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Parent 2 0 R
+  /Prev 11 0 R
+  /Title (Page 4)
+>>
+endobj
+
 %% Page 1
 %% Original object ID: 70 0
-3 0 obj
+6 0 obj
 <<
-  /Annots 7 0 R
-  /Contents 8 0 R
+  /Annots 12 0 R
+  /Contents 13 0 R
   /Group <<
     /CS /DeviceRGB
     /I true
@@ -41,10 +86,10 @@ endobj
     612
     792
   ]
-  /Parent 2 0 R
+  /Parent 3 0 R
   /Resources <<
     /Font <<
-      /F2 10 0 R
+      /F2 15 0 R
     >>
     /ProcSet [
       /PDF
@@ -57,10 +102,10 @@ endobj
 
 %% Page 2
 %% Original object ID: 71 0
-4 0 obj
+7 0 obj
 <<
-  /Annots 11 0 R
-  /Contents 12 0 R
+  /Annots 16 0 R
+  /Contents 17 0 R
   /Group <<
     /CS /DeviceRGB
     /I true
@@ -72,10 +117,10 @@ endobj
     612
     792
   ]
-  /Parent 2 0 R
+  /Parent 3 0 R
   /Resources <<
     /Font <<
-      /F2 10 0 R
+      /F2 15 0 R
     >>
     /ProcSet [
       /PDF
@@ -88,10 +133,10 @@ endobj
 
 %% Page 3
 %% Original object ID: 72 0
-5 0 obj
+8 0 obj
 <<
-  /Annots 14 0 R
-  /Contents 15 0 R
+  /Annots 19 0 R
+  /Contents 20 0 R
   /Group <<
     /CS /DeviceRGB
     /I true
@@ -103,10 +148,10 @@ endobj
     612
     792
   ]
-  /Parent 2 0 R
+  /Parent 3 0 R
   /Resources <<
     /Font <<
-      /F2 10 0 R
+      /F2 15 0 R
     >>
     /ProcSet [
       /PDF
@@ -119,10 +164,10 @@ endobj
 
 %% Page 4
 %% Original object ID: 73 0
-6 0 obj
+9 0 obj
 <<
-  /Annots 17 0 R
-  /Contents 18 0 R
+  /Annots 22 0 R
+  /Contents 23 0 R
   /Group <<
     /CS /DeviceRGB
     /I true
@@ -134,10 +179,10 @@ endobj
     612
     792
   ]
-  /Parent 2 0 R
+  /Parent 3 0 R
   /Resources <<
     /Font <<
-      /F2 10 0 R
+      /F2 15 0 R
     >>
     /ProcSet [
       /PDF
@@ -148,21 +193,57 @@ endobj
 >>
 endobj
 
+%% Original object ID: 76 0
+10 0 obj
+<<
+  /Count 0
+  /Dest [
+    7 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 11 0 R
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (Page 2)
+>>
+endobj
+
+%% Original object ID: 77 0
+11 0 obj
+<<
+  /Count 0
+  /Dest [
+    8 0 R
+    /XYZ
+    56.7
+    773.189
+    0
+  ]
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Prev 10 0 R
+  /Title (Page 3)
+>>
+endobj
+
 %% Original object ID: 16 0
-7 0 obj
+12 0 obj
 [
-  20 0 R
-  21 0 R
-  22 0 R
-  23 0 R
+  25 0 R
+  26 0 R
+  27 0 R
+  28 0 R
 ]
 endobj
 
 %% Contents for page 1
 %% Original object ID: 11 0
-8 0 obj
+13 0 obj
 <<
-  /Length 9 0 R
+  /Length 14 0 R
 >>
 stream
 0.1 w
@@ -201,12 +282,12 @@ endstream
 endobj
 
 %QDF: ignore_newline
-9 0 obj
+14 0 obj
 314
 endobj
 
 %% Original object ID: 15 0
-10 0 obj
+15 0 obj
 <<
   /BaseFont /Courier
   /Subtype /TrueType
@@ -215,20 +296,20 @@ endobj
 endobj
 
 %% Original object ID: 31 0
-11 0 obj
+16 0 obj
 [
-  24 0 R
-  25 0 R
-  26 0 R
-  27 0 R
+  29 0 R
+  30 0 R
+  31 0 R
+  32 0 R
 ]
 endobj
 
 %% Contents for page 2
 %% Original object ID: 29 0
-12 0 obj
+17 0 obj
 <<
-  /Length 13 0 R
+  /Length 18 0 R
 >>
 stream
 0.1 w
@@ -267,25 +348,25 @@ endstream
 endobj
 
 %QDF: ignore_newline
-13 0 obj
+18 0 obj
 314
 endobj
 
 %% Original object ID: 46 0
-14 0 obj
+19 0 obj
 [
-  28 0 R
-  29 0 R
-  30 0 R
-  31 0 R
+  33 0 R
+  34 0 R
+  35 0 R
+  36 0 R
 ]
 endobj
 
 %% Contents for page 3
 %% Original object ID: 44 0
-15 0 obj
+20 0 obj
 <<
-  /Length 16 0 R
+  /Length 21 0 R
 >>
 stream
 0.1 w
@@ -324,25 +405,25 @@ endstream
 endobj
 
 %QDF: ignore_newline
-16 0 obj
+21 0 obj
 314
 endobj
 
 %% Original object ID: 61 0
-17 0 obj
+22 0 obj
 [
-  32 0 R
-  33 0 R
-  34 0 R
-  35 0 R
+  37 0 R
+  38 0 R
+  39 0 R
+  40 0 R
 ]
 endobj
 
 %% Contents for page 4
 %% Original object ID: 59 0
-18 0 obj
+23 0 obj
 <<
-  /Length 19 0 R
+  /Length 24 0 R
 >>
 stream
 0.1 w
@@ -381,12 +462,12 @@ endstream
 endobj
 
 %QDF: ignore_newline
-19 0 obj
+24 0 obj
 314
 endobj
 
 %% Original object ID: 17 0
-20 0 obj
+25 0 obj
 <<
   /Border [
     0
@@ -394,7 +475,7 @@ endobj
     0
   ]
   /Dest [
-    36 0 R
+    41 0 R
     /XYZ
     56.7
     773.189
@@ -412,7 +493,7 @@ endobj
 endobj
 
 %% Original object ID: 19 0
-21 0 obj
+26 0 obj
 <<
   /Border [
     0
@@ -420,7 +501,7 @@ endobj
     0
   ]
   /Dest [
-    37 0 R
+    42 0 R
     /XYZ
     56.7
     773.189
@@ -438,7 +519,7 @@ endobj
 endobj
 
 %% Original object ID: 21 0
-22 0 obj
+27 0 obj
 <<
   /Border [
     0
@@ -446,7 +527,7 @@ endobj
     0
   ]
   /Dest [
-    38 0 R
+    43 0 R
     /XYZ
     56.7
     773.189
@@ -464,7 +545,7 @@ endobj
 endobj
 
 %% Original object ID: 23 0
-23 0 obj
+28 0 obj
 <<
   /Border [
     0
@@ -472,7 +553,7 @@ endobj
     0
   ]
   /Dest [
-    39 0 R
+    44 0 R
     /XYZ
     56.7
     773.189
@@ -490,7 +571,7 @@ endobj
 endobj
 
 %% Original object ID: 32 0
-24 0 obj
+29 0 obj
 <<
   /Border [
     0
@@ -498,7 +579,7 @@ endobj
     0
   ]
   /Dest [
-    40 0 R
+    45 0 R
     /XYZ
     56.7
     773.189
@@ -516,7 +597,7 @@ endobj
 endobj
 
 %% Original object ID: 34 0
-25 0 obj
+30 0 obj
 <<
   /Border [
     0
@@ -524,7 +605,7 @@ endobj
     0
   ]
   /Dest [
-    41 0 R
+    46 0 R
     /XYZ
     56.7
     773.189
@@ -542,7 +623,7 @@ endobj
 endobj
 
 %% Original object ID: 36 0
-26 0 obj
+31 0 obj
 <<
   /Border [
     0
@@ -550,7 +631,7 @@ endobj
     0
   ]
   /Dest [
-    42 0 R
+    47 0 R
     /XYZ
     56.7
     773.189
@@ -568,7 +649,7 @@ endobj
 endobj
 
 %% Original object ID: 38 0
-27 0 obj
+32 0 obj
 <<
   /Border [
     0
@@ -576,7 +657,7 @@ endobj
     0
   ]
   /Dest [
-    43 0 R
+    48 0 R
     /XYZ
     56.7
     773.189
@@ -594,7 +675,7 @@ endobj
 endobj
 
 %% Original object ID: 47 0
-28 0 obj
+33 0 obj
 <<
   /Border [
     0
@@ -602,7 +683,7 @@ endobj
     0
   ]
   /Dest [
-    44 0 R
+    49 0 R
     /XYZ
     56.7
     773.189
@@ -620,7 +701,7 @@ endobj
 endobj
 
 %% Original object ID: 49 0
-29 0 obj
+34 0 obj
 <<
   /Border [
     0
@@ -628,7 +709,7 @@ endobj
     0
   ]
   /Dest [
-    45 0 R
+    50 0 R
     /XYZ
     56.7
     773.189
@@ -646,7 +727,7 @@ endobj
 endobj
 
 %% Original object ID: 51 0
-30 0 obj
+35 0 obj
 <<
   /Border [
     0
@@ -654,7 +735,7 @@ endobj
     0
   ]
   /Dest [
-    46 0 R
+    51 0 R
     /XYZ
     56.7
     773.189
@@ -672,7 +753,7 @@ endobj
 endobj
 
 %% Original object ID: 53 0
-31 0 obj
+36 0 obj
 <<
   /Border [
     0
@@ -680,7 +761,7 @@ endobj
     0
   ]
   /Dest [
-    47 0 R
+    52 0 R
     /XYZ
     56.7
     773.189
@@ -698,7 +779,7 @@ endobj
 endobj
 
 %% Original object ID: 62 0
-32 0 obj
+37 0 obj
 <<
   /Border [
     0
@@ -706,7 +787,7 @@ endobj
     0
   ]
   /Dest [
-    48 0 R
+    53 0 R
     /XYZ
     56.7
     773.189
@@ -724,7 +805,7 @@ endobj
 endobj
 
 %% Original object ID: 64 0
-33 0 obj
+38 0 obj
 <<
   /Border [
     0
@@ -732,7 +813,7 @@ endobj
     0
   ]
   /Dest [
-    49 0 R
+    54 0 R
     /XYZ
     56.7
     773.189
@@ -750,7 +831,7 @@ endobj
 endobj
 
 %% Original object ID: 66 0
-34 0 obj
+39 0 obj
 <<
   /Border [
     0
@@ -758,7 +839,7 @@ endobj
     0
   ]
   /Dest [
-    50 0 R
+    55 0 R
     /XYZ
     56.7
     773.189
@@ -776,7 +857,7 @@ endobj
 endobj
 
 %% Original object ID: 68 0
-35 0 obj
+40 0 obj
 <<
   /Border [
     0
@@ -784,7 +865,7 @@ endobj
     0
   ]
   /Dest [
-    51 0 R
+    56 0 R
     /XYZ
     56.7
     773.189
@@ -802,144 +883,149 @@ endobj
 endobj
 
 %% Original object ID: 18 0
-36 0 obj
-null
-endobj
-
-%% Original object ID: 20 0
-37 0 obj
-null
-endobj
-
-%% Original object ID: 22 0
-38 0 obj
-null
-endobj
-
-%% Original object ID: 24 0
-39 0 obj
-null
-endobj
-
-%% Original object ID: 33 0
-40 0 obj
-null
-endobj
-
-%% Original object ID: 35 0
 41 0 obj
 null
 endobj
 
-%% Original object ID: 37 0
+%% Original object ID: 20 0
 42 0 obj
 null
 endobj
 
-%% Original object ID: 39 0
+%% Original object ID: 22 0
 43 0 obj
 null
 endobj
 
-%% Original object ID: 48 0
+%% Original object ID: 24 0
 44 0 obj
 null
 endobj
 
-%% Original object ID: 50 0
+%% Original object ID: 33 0
 45 0 obj
 null
 endobj
 
-%% Original object ID: 52 0
+%% Original object ID: 35 0
 46 0 obj
 null
 endobj
 
-%% Original object ID: 54 0
+%% Original object ID: 37 0
 47 0 obj
 null
 endobj
 
-%% Original object ID: 63 0
+%% Original object ID: 39 0
 48 0 obj
 null
 endobj
 
-%% Original object ID: 65 0
+%% Original object ID: 48 0
 49 0 obj
 null
 endobj
 
-%% Original object ID: 67 0
+%% Original object ID: 50 0
 50 0 obj
 null
 endobj
 
-%% Original object ID: 69 0
+%% Original object ID: 52 0
 51 0 obj
 null
 endobj
 
+%% Original object ID: 54 0
+52 0 obj
+null
+endobj
+
+%% Original object ID: 63 0
+53 0 obj
+null
+endobj
+
+%% Original object ID: 65 0
+54 0 obj
+null
+endobj
+
+%% Original object ID: 67 0
+55 0 obj
+null
+endobj
+
+%% Original object ID: 69 0
+56 0 obj
+null
+endobj
+
 xref
-0 52
+0 57
 0000000000 65535 f 
 0000000052 00000 n 
-0000000133 00000 n 
-0000000273 00000 n 
-0000000614 00000 n 
-0000000957 00000 n 
-0000001300 00000 n 
-0000001633 00000 n 
-0000001740 00000 n 
-0000002131 00000 n 
-0000002179 00000 n 
+0000000152 00000 n 
+0000000259 00000 n 
+0000000389 00000 n 
+0000000559 00000 n 
+0000000739 00000 n 
+0000001082 00000 n 
+0000001425 00000 n 
+0000001768 00000 n 
+0000002101 00000 n 
 0000002286 00000 n 
-0000002394 00000 n 
-0000002787 00000 n 
-0000002836 00000 n 
-0000002944 00000 n 
-0000003337 00000 n 
-0000003386 00000 n 
-0000003494 00000 n 
-0000003887 00000 n 
-0000003936 00000 n 
-0000004159 00000 n 
-0000004382 00000 n 
-0000004605 00000 n 
-0000004828 00000 n 
-0000005051 00000 n 
-0000005274 00000 n 
-0000005497 00000 n 
-0000005720 00000 n 
-0000005943 00000 n 
-0000006166 00000 n 
-0000006389 00000 n 
-0000006612 00000 n 
-0000006835 00000 n 
-0000007058 00000 n 
-0000007281 00000 n 
-0000007504 00000 n 
-0000007554 00000 n 
-0000007604 00000 n 
-0000007654 00000 n 
-0000007704 00000 n 
-0000007754 00000 n 
-0000007804 00000 n 
-0000007854 00000 n 
-0000007904 00000 n 
-0000007954 00000 n 
-0000008004 00000 n 
-0000008054 00000 n 
-0000008104 00000 n 
-0000008154 00000 n 
-0000008204 00000 n 
-0000008254 00000 n 
+0000002471 00000 n 
+0000002579 00000 n 
+0000002972 00000 n 
+0000003021 00000 n 
+0000003128 00000 n 
+0000003236 00000 n 
+0000003629 00000 n 
+0000003678 00000 n 
+0000003786 00000 n 
+0000004179 00000 n 
+0000004228 00000 n 
+0000004336 00000 n 
+0000004729 00000 n 
+0000004778 00000 n 
+0000005001 00000 n 
+0000005224 00000 n 
+0000005447 00000 n 
+0000005670 00000 n 
+0000005893 00000 n 
+0000006116 00000 n 
+0000006339 00000 n 
+0000006562 00000 n 
+0000006785 00000 n 
+0000007008 00000 n 
+0000007231 00000 n 
+0000007454 00000 n 
+0000007677 00000 n 
+0000007900 00000 n 
+0000008123 00000 n 
+0000008346 00000 n 
+0000008396 00000 n 
+0000008446 00000 n 
+0000008496 00000 n 
+0000008546 00000 n 
+0000008596 00000 n 
+0000008646 00000 n 
+0000008696 00000 n 
+0000008746 00000 n 
+0000008796 00000 n 
+0000008846 00000 n 
+0000008896 00000 n 
+0000008946 00000 n 
+0000008996 00000 n 
+0000009046 00000 n 
+0000009096 00000 n 
 trailer <<
   /Root 1 0 R
-  /Size 52
+  /Size 57
   /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
 >>
 startxref
-8276
+9118
 %%EOF

--- a/tests/test_exporter_outlines.py
+++ b/tests/test_exporter_outlines.py
@@ -1,0 +1,852 @@
+"""Tests for outline.py — bookmark remapping when pdfarranger reorders/subsets pages.
+
+Each test builds minimal synthetic PDFs with pikepdf directly, so there are no
+fixture files and the suite stays fast and self-contained.
+
+Helper conventions:
+  make_pdf(n)          → pikepdf.Pdf with n blank pages, no outline
+  Row(nfile, npage)    → minimal stand-in for pdfarranger's page-row object
+  roundtrip(pdf)       → save + reopen so all object references are resolved
+  dest_page_index(pdf, dest_array) → which 0-based page index a dest array points to
+"""
+
+import io
+import builtins
+
+import pikepdf
+import pytest
+from unittest.mock import patch
+
+from pdfarranger.exporter_outlines import rebuild_outlines, write_named_dests
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_pdf(n_pages: int) -> pikepdf.Pdf:
+    """Return a new in-memory Pdf with n_pages blank pages."""
+    pdf = pikepdf.new()
+    for _ in range(n_pages):
+        pdf.pages.append(
+            pikepdf.Page(
+                pikepdf.Dictionary(
+                    Type=pikepdf.Name.Page,
+                    MediaBox=[0, 0, 612, 792],
+                )
+            )
+        )
+    return pdf
+
+
+def add_outline(pdf: pikepdf.Pdf, items):
+    """Add bookmarks to pdf from a list of tuples.
+
+    Each tuple is either (title, page_idx) or
+    (title, page_idx, [(child_title, child_page_idx), ...]) tuples.
+    """
+    with pdf.open_outline() as ol:
+        for entry in items:
+            if len(entry) == 2:
+                title, page_idx = entry
+                children = []
+            else:
+                title, page_idx, children = entry
+            item = pikepdf.OutlineItem(title, page_idx)
+            for child_title, child_page_idx in children:
+                item.children.append(pikepdf.OutlineItem(child_title, child_page_idx))
+            ol.root.append(item)
+
+
+def add_named_dest(pdf: pikepdf.Pdf, name: str, page_idx: int):
+    """Add a single named destination pointing to page_idx."""
+    if pikepdf.Name.Names not in pdf.Root:
+        pdf.Root.Names = pdf.make_indirect(pikepdf.Dictionary())
+    if pikepdf.Name.Dests in pdf.Root.Names:
+        nt = pikepdf.NameTree(pdf.Root.Names.Dests)
+    else:
+        nt = pikepdf.NameTree.new(pdf)
+        pdf.Root.Names.Dests = nt.obj
+    dest_array = pikepdf.Array([pdf.pages[page_idx].obj, pikepdf.Name.Fit])
+    nt[name] = dest_array
+
+
+def add_named_dest_bookmark(pdf: pikepdf.Pdf, title: str, dest_name: str):
+    """Add a bookmark that references a named destination by string."""
+    with pdf.open_outline() as ol:
+        item = pikepdf.OutlineItem(title, pikepdf.String(dest_name))
+        ol.root.append(item)
+
+
+def roundtrip(pdf: pikepdf.Pdf) -> pikepdf.Pdf:
+    """Save to a BytesIO buffer and reopen — resolves all indirect references."""
+    buf = io.BytesIO()
+    pdf.save(buf)
+    buf.seek(0)
+    return pikepdf.open(buf)
+
+
+def dest_page_index(output_pdf: pikepdf.Pdf, dest_array) -> int:
+    """
+    Given a destination array from an outline item in output_pdf,
+    return the 0-based page index it resolves to.
+    """
+    page_obj = dest_array[0]
+    for i, page in enumerate(output_pdf.pages):
+        if page.obj.objgen == page_obj.objgen:
+            return i
+    raise ValueError(f"Destination page not found in output PDF: {dest_array}")
+
+
+def named_dest_page_index(output_pdf: pikepdf.Pdf, name: str) -> int:
+    """Look up a named destination in output_pdf and return its page index."""
+    nt = dict(pikepdf.NameTree(output_pdf.Root.Names.Dests).items())
+    dest_array = nt[name]
+    return dest_page_index(output_pdf, dest_array)
+
+
+class Row:
+    """Minimal stand-in for pdfarranger's page-row model object."""
+
+    def __init__(self, nfile: int, npage: int):
+        """Initialize with 1-based file/page indices."""
+        self.nfile = nfile
+        self.npage = npage
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic single-file cases
+# ---------------------------------------------------------------------------
+
+
+class TestSingleFileIdentity:
+    """All pages kept in original order — bookmarks should be preserved as-is."""
+
+    def test_single_bookmark(self):
+        src = make_pdf(3)
+        add_outline(src, [("Chapter 1", 0), ("Chapter 2", 1), ("Chapter 3", 2)])
+        src = roundtrip(src)
+
+        out = make_pdf(3)
+        pages = [Row(1, 1), Row(1, 2), Row(1, 3)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert [item.title for item in ol.root] == [
+                "Chapter 1",
+                "Chapter 2",
+                "Chapter 3",
+            ]
+            assert dest_page_index(out, ol.root[0].destination) == 0
+            assert dest_page_index(out, ol.root[1].destination) == 1
+            assert dest_page_index(out, ol.root[2].destination) == 2
+
+    def test_no_outline_produces_no_outline(self):
+        src = make_pdf(2)
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 2)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root == []
+
+
+class TestPageSubset:
+    """Only a subset of pages is kept — bookmarks to excluded pages must be dropped."""
+
+    def test_bookmark_to_excluded_page_is_dropped(self):
+        src = make_pdf(3)
+        add_outline(src, [("Keep", 0), ("Drop", 1), ("Also keep", 2)])
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 3)]  # page 2 excluded
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            titles = [item.title for item in ol.root]
+            assert "Drop" not in titles
+            assert "Keep" in titles
+            assert "Also keep" in titles
+
+    def test_bookmark_targets_remapped_to_new_positions(self):
+        src = make_pdf(3)
+        add_outline(src, [("First", 0), ("Third", 2)])
+        src = roundtrip(src)
+
+        # Keep only pages 1 and 3, so output page 0 = src page 0, output page 1 = src page 2
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 3)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert dest_page_index(out, ol.root[0].destination) == 0
+            assert dest_page_index(out, ol.root[1].destination) == 1
+
+    def test_all_bookmarks_excluded_leaves_empty_outline(self):
+        src = make_pdf(3)
+        add_outline(src, [("Page 2", 1), ("Page 3", 2)])
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        pages = [Row(1, 1)]  # only page 1 kept, neither bookmark target survives
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root == []
+
+
+class TestPageReordering:
+    """Pages reordered — bookmark destinations must follow their pages."""
+
+    def test_reversed_pages(self):
+        src = make_pdf(3)
+        add_outline(src, [("A", 0), ("B", 1), ("C", 2)])
+        src = roundtrip(src)
+
+        out = make_pdf(3)
+        pages = [Row(1, 3), Row(1, 2), Row(1, 1)]  # reversed
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            # "A" pointed to src page 0, which is now output page 2
+            assert dest_page_index(out, ol.root[0].destination) == 2
+            # "B" → src page 1 → output page 1
+            assert dest_page_index(out, ol.root[1].destination) == 1
+            # "C" → src page 2 → output page 0
+            assert dest_page_index(out, ol.root[2].destination) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: nested bookmarks
+# ---------------------------------------------------------------------------
+
+
+class TestNestedBookmarks:
+    def test_nested_children_preserved(self):
+        src = make_pdf(3)
+        add_outline(src, [("Chapter 1", 0, [("Section 1.1", 1), ("Section 1.2", 2)])])
+        src = roundtrip(src)
+
+        out = make_pdf(3)
+        pages = [Row(1, 1), Row(1, 2), Row(1, 3)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root[0].title == "Chapter 1"
+            children = ol.root[0].children
+            assert len(children) == 2
+            assert children[0].title == "Section 1.1"
+            assert children[1].title == "Section 1.2"
+            assert dest_page_index(out, children[0].destination) == 1
+            assert dest_page_index(out, children[1].destination) == 2
+
+    def test_parent_dropped_but_valid_children_promoted(self):
+        """
+        Parent bookmark points to an excluded page, but its children point to
+        included pages. The parent should still appear (with no valid dest of
+        its own) because it has surviving children.
+        """
+        src = make_pdf(3)
+        add_outline(
+            src,
+            [
+                ("Chapter", 0, [("Section", 2)])  # parent→p0 excluded, child→p2 kept
+            ],
+        )
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 2), Row(1, 3)]  # pages 2 and 3 only
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            # Parent must still exist because child survived
+            assert len(ol.root) == 1
+            assert ol.root[0].title == "Chapter"
+            assert len(ol.root[0].children) == 1
+            assert ol.root[0].children[0].title == "Section"
+
+    def test_parent_and_all_children_excluded_produces_nothing(self):
+        src = make_pdf(4)
+        add_outline(src, [("Drop everything", 0, [("Also drop", 1)])])
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 3), Row(1, 4)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root == []
+
+    def test_parent_without_destination_is_kept_if_child_survives(self):
+        """A bookmark acting purely as a folder (no dest) hits the fallback return None."""
+        src = make_pdf(1)
+        with src.open_outline() as ol:
+            # Create a parent with no destination or action (this hits line 148)
+            parent = pikepdf.OutlineItem("Folder")
+            # Give it a child with a valid destination so it survives the prune check
+            child = pikepdf.OutlineItem("Child", 0)
+            parent.children.append(child)
+            ol.root.append(parent)
+        src = roundtrip(src)
+        out = make_pdf(1)
+        pages = [Row(1, 1)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+        with out.open_outline() as ol:
+            assert len(ol.root) == 1
+            # Parent survives and remains destination-less
+            assert ol.root[0].title == "Folder"
+            assert ol.root[0].destination is None
+            # Child survives and points to the correct page
+            assert len(ol.root[0].children) == 1
+            assert ol.root[0].children[0].title == "Child"
+            assert dest_page_index(out, ol.root[0].children[0].destination) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: named destinations
+# ---------------------------------------------------------------------------
+
+
+class TestNamedDestinations:
+    def test_named_dest_bookmark_remapped(self):
+        src = make_pdf(3)
+        add_named_dest(src, "chapter-one", 1)  # points to page index 1
+        add_named_dest_bookmark(src, "Chapter One", "chapter-one")
+        src = roundtrip(src)
+
+        out = make_pdf(3)
+        pages = [Row(1, 1), Row(1, 2), Row(1, 3)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert len(ol.root) == 1
+            assert ol.root[0].title == "Chapter One"
+
+        # The named dest should exist in the output under the remapped name
+        assert named_dest_page_index(out, "f0-chapter-one") == 1
+
+    def test_named_dest_to_excluded_page_is_dropped(self):
+        src = make_pdf(3)
+        add_named_dest(src, "excluded", 1)  # page index 1 will be excluded
+        add_named_dest_bookmark(src, "Excluded Chapter", "excluded")
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 3)]  # page 2 (index 1) excluded
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root == []
+
+    def test_named_dest_target_follows_reordering(self):
+        src = make_pdf(3)
+        add_named_dest(src, "last", 2)  # originally page index 2 (last)
+        add_named_dest_bookmark(src, "Last Page", "last")
+        src = roundtrip(src)
+
+        # Reverse page order
+        out = make_pdf(3)
+        pages = [Row(1, 3), Row(1, 2), Row(1, 1)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        # src page 2 is now output page 0 after reversal
+        assert named_dest_page_index(out, "f0-last") == 0
+
+    def test_unknown_named_dest_is_dropped(self):
+        """Bookmark references a named dest that doesn't exist in the source PDF."""
+        src = make_pdf(2)
+        # Manually add a bookmark with a named dest that has no entry in the dest table
+        with src.open_outline() as ol:
+            ol.root.append(pikepdf.OutlineItem("Ghost", pikepdf.String("nonexistent")))
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 2)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: multi-file merge
+# ---------------------------------------------------------------------------
+
+
+class TestMultiFileMerge:
+    def test_bookmarks_from_both_files_appear(self):
+        src_a = make_pdf(2)
+        add_outline(src_a, [("File A Ch1", 0), ("File A Ch2", 1)])
+        src_a = roundtrip(src_a)
+
+        src_b = make_pdf(2)
+        add_outline(src_b, [("File B Ch1", 0), ("File B Ch2", 1)])
+        src_b = roundtrip(src_b)
+
+        out = make_pdf(4)
+        pages = [Row(1, 1), Row(1, 2), Row(2, 1), Row(2, 2)]
+        rebuild_outlines([src_a, src_b], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            titles = [item.title for item in ol.root]
+            assert "File A Ch1" in titles
+            assert "File A Ch2" in titles
+            assert "File B Ch1" in titles
+            assert "File B Ch2" in titles
+
+    def test_bookmarks_point_to_correct_output_pages_after_merge(self):
+        src_a = make_pdf(2)
+        add_outline(src_a, [("A1", 0), ("A2", 1)])
+        src_a = roundtrip(src_a)
+
+        src_b = make_pdf(2)
+        add_outline(src_b, [("B1", 0), ("B2", 1)])
+        src_b = roundtrip(src_b)
+
+        # Interleave: A1, B1, A2, B2
+        out = make_pdf(4)
+        pages = [Row(1, 1), Row(2, 1), Row(1, 2), Row(2, 2)]
+        rebuild_outlines([src_a, src_b], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            by_title = {item.title: item for item in ol.root}
+            assert dest_page_index(out, by_title["A1"].destination) == 0
+            assert dest_page_index(out, by_title["B1"].destination) == 1
+            assert dest_page_index(out, by_title["A2"].destination) == 2
+            assert dest_page_index(out, by_title["B2"].destination) == 3
+
+    def test_file_with_no_outline_is_skipped_gracefully(self):
+        src_a = make_pdf(2)
+        add_outline(src_a, [("Only A", 0)])
+        src_a = roundtrip(src_a)
+
+        src_b = make_pdf(2)  # no outline
+        src_b = roundtrip(src_b)
+
+        out = make_pdf(4)
+        pages = [Row(1, 1), Row(1, 2), Row(2, 1), Row(2, 2)]
+        rebuild_outlines([src_a, src_b], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert len(ol.root) == 1
+            assert ol.root[0].title == "Only A"
+
+    def test_named_dest_collision_across_files_both_survive(self):
+        """
+        Both files have a named dest called 'intro'. After merge they should
+        become 'f0-intro' and 'f1-intro' — neither should overwrite the other.
+        """
+        src_a = make_pdf(2)
+        add_named_dest(src_a, "intro", 0)
+        add_named_dest_bookmark(src_a, "Intro A", "intro")
+        src_a = roundtrip(src_a)
+
+        src_b = make_pdf(2)
+        add_named_dest(src_b, "intro", 0)
+        add_named_dest_bookmark(src_b, "Intro B", "intro")
+        src_b = roundtrip(src_b)
+
+        out = make_pdf(4)
+        pages = [Row(1, 1), Row(1, 2), Row(2, 1), Row(2, 2)]
+        rebuild_outlines([src_a, src_b], out, pages)
+        out = roundtrip(out)
+
+        # Both named dests must exist
+        nt = dict(pikepdf.NameTree(out.Root.Names.Dests).items())
+        assert "f0-intro" in nt
+        assert "f1-intro" in nt
+        # And point to the right output pages
+        assert named_dest_page_index(out, "f0-intro") == 0
+        assert named_dest_page_index(out, "f1-intro") == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: duplicate pages
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicatePages:
+    def test_bookmark_targets_first_copy_of_duplicated_page(self):
+        """
+        When a source page appears twice in the output, bookmarks should
+        resolve to the first copy (instance 0).
+        """
+        src = make_pdf(2)
+        add_outline(src, [("Chapter", 0)])
+        src = roundtrip(src)
+
+        out = make_pdf(3)
+        # Page 1 appears at output positions 0 and 2
+        pages = [Row(1, 1), Row(1, 2), Row(1, 1)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert dest_page_index(out, ol.root[0].destination) == 0  # first copy
+
+
+# ---------------------------------------------------------------------------
+# Tests: edge cases and error handling
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_pages_list(self):
+        src = make_pdf(2)
+        add_outline(src, [("Chapter", 0)])
+        src = roundtrip(src)
+
+        out = pikepdf.new()
+        rebuild_outlines([src], out, [])
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root == []
+
+    def test_none_pdf_in_input_list_is_skipped(self):
+        src = make_pdf(2)
+        add_outline(src, [("Chapter", 0)])
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        # pdf_input[0] is None, pdf_input[1] is our src
+        pages = [Row(2, 1), Row(2, 2)]
+        rebuild_outlines([None, src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as ol:
+            assert ol.root[0].title == "Chapter"
+
+    def test_warning_emitted_on_corrupt_outline(self):
+        """
+        If pikepdf raises PdfError while reading a source outline,
+        rebuild_outlines should warn rather than crash.
+        """
+        src = make_pdf(2)
+        add_outline(src, [("Chapter", 0)])
+        src = roundtrip(src)
+
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 2)]
+
+        with patch.object(
+            src,
+            "open_outline",
+            side_effect=pikepdf.PdfError("Corrupt outline structure"),
+        ):
+            with pytest.warns(
+                UserWarning,
+                match="Failed to copy bookmarks from document 1:",
+            ):
+                rebuild_outlines([src], out, pages)
+
+    def test_write_named_dests_no_op_on_empty_list(self):
+        pdf = make_pdf(1)
+        write_named_dests(pdf, [])  # must not crash or create spurious structure
+        assert pikepdf.Name.Names not in pdf.Root
+
+    def test_write_named_dests_creates_name_tree_when_absent(self):
+        pdf = make_pdf(2)
+        dest_array = pikepdf.Array([pdf.pages[1].obj, pikepdf.Name.Fit])
+        write_named_dests(pdf, [("my-dest", dest_array)])
+        pdf = roundtrip(pdf)
+
+        nt = dict(pikepdf.NameTree(pdf.Root.Names.Dests).items())
+        assert "my-dest" in nt
+
+    def test_write_named_dests_merges_into_existing_name_tree(self):
+        pdf = make_pdf(3)
+        # Pre-populate a NameTree
+        add_named_dest(pdf, "existing", 0)
+        # Now add a new one via write_named_dests
+        dest_array = pikepdf.Array([pdf.pages[2].obj, pikepdf.Name.Fit])
+        write_named_dests(pdf, [("new-dest", dest_array)])
+        pdf = roundtrip(pdf)
+
+        nt = dict(pikepdf.NameTree(pdf.Root.Names.Dests).items())
+        assert "existing" in nt
+        assert "new-dest" in nt
+
+    def test_pdf_1_1_dests_and_indirect_coords(self):
+        src = make_pdf(1)
+        indirect_zoom = src.make_indirect(pikepdf.Dictionary(Zoom=1))
+        dest_arr = pikepdf.Array(
+            [src.pages[0].obj, pikepdf.Name.XYZ, 0, 0, indirect_zoom]
+        )
+        src.Root.Dests = pikepdf.Dictionary({"/old_style_dest": dest_arr})
+
+        with src.open_outline() as outline:
+            item = pikepdf.OutlineItem("Old Dest Item")
+            item.destination = pikepdf.Name("/old_style_dest")
+            outline.root.append(item)
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        pages = [Row(1, 1)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as outline:
+            assert len(outline.root) == 1
+            assert outline.root[0].title == "Old Dest Item"
+
+    def test_invalid_destinations_dropped(self):
+        src = make_pdf(1)
+        with src.open_outline() as outline:
+            # Empty array bypassed via action dictionary
+            item1 = pikepdf.OutlineItem("Empty Array")
+            item1.action = pikepdf.Dictionary(S=pikepdf.Name.GoTo, D=pikepdf.Array())
+            outline.root.append(item1)
+
+            # Invalid type (Dictionary) bypassed via action dictionary
+            item2 = pikepdf.OutlineItem("Invalid Type")
+            item2.action = pikepdf.Dictionary(
+                S=pikepdf.Name.GoTo, D=pikepdf.Dictionary()
+            )
+            outline.root.append(item2)
+
+            # Target page object isn't in rev_map
+            dummy_obj = src.make_indirect(pikepdf.String("Not a page"))
+            item3 = pikepdf.OutlineItem("Foreign Page Object")
+            item3.destination = pikepdf.Array([dummy_obj, pikepdf.Name.Fit])
+            outline.root.append(item3)
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        pages = [Row(1, 1)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as outline:
+            assert len(outline.root) == 0
+
+    def test_missing_objgen_dropped(self):
+        src = make_pdf(1)
+        with src.open_outline() as outline:
+            item = pikepdf.OutlineItem("No Objgen")
+            item.destination = pikepdf.Array([src.pages[0].obj, pikepdf.Name.Fit])
+            outline.root.append(item)
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        pages = [Row(1, 1)]
+
+        original_hasattr = builtins.hasattr
+
+        def mock_hasattr(obj, attr_name):
+            if attr_name == "objgen":
+                return False
+            return original_hasattr(obj, attr_name)
+
+        with patch("builtins.hasattr", side_effect=mock_hasattr):
+            rebuild_outlines([src], out, pages)
+
+        with out.open_outline() as outline:
+            assert len(outline.root) == 0
+
+    def test_goto_action_outline(self):
+        src = make_pdf(1)
+        with src.open_outline() as outline:
+            item = pikepdf.OutlineItem("Action Item")
+            item.action = pikepdf.Dictionary(
+                S=pikepdf.Name.GoTo,
+                D=pikepdf.Array([src.pages[0].obj, pikepdf.Name.Fit]),
+            )
+            outline.root.append(item)
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        pages = [Row(1, 1)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+
+        with out.open_outline() as outline:
+            assert len(outline.root) == 1
+            assert outline.root[0].title == "Action Item"
+
+    def test_pdf_error_warning_during_copy(self):
+        src = make_pdf(1)
+        add_outline(src, [("Trigger", 0)])
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        pages = [Row(1, 1)]
+
+        with patch(
+            "pdfarranger.exporter_outlines.OutlineCopier.copy_item",
+            side_effect=pikepdf.PdfError("Corrupted Tree!"),
+        ):
+            with pytest.warns(
+                UserWarning,
+                match="Failed to copy bookmarks from document 1: Corrupted Tree!",
+            ):
+                rebuild_outlines([src], out, pages)
+
+
+class TestScaling:
+    def test_various_fit_types_scaling(self):
+        """Test scaling for FitH, FitV, FitBH, FitBV (single coordinate types)."""
+        src = make_pdf(1)
+        # Each of these takes one coordinate (top or left) at index 2
+        types = [
+            pikepdf.Name.FitH,
+            pikepdf.Name.FitV,
+            pikepdf.Name.FitBH,
+            pikepdf.Name.FitBV,
+        ]
+        with src.open_outline() as ol:
+            for t in types:
+                ol.root.append(
+                    pikepdf.OutlineItem(
+                        str(t), pikepdf.Array([src.pages[0].obj, t, 50])
+                    )
+                )
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        row = Row(1, 1)
+        row.scale = 0.5
+        rebuild_outlines([src], out, [row])
+
+        with out.open_outline() as ol:
+            for i in range(len(types)):
+                assert ol.root[i].destination[2] == 25.0
+
+    def test_invalid_destination_structures(self):
+        """Test handling of malformed destination objects."""
+        src = make_pdf(1)
+        with src.open_outline() as ol:
+            # Case 1: Destination array too short
+            ol.root.append(
+                pikepdf.OutlineItem("Too Short", pikepdf.Array([src.pages[0].obj]))
+            )
+            # Case 2: First element is not a page reference (no objgen)
+            ol.root.append(
+                pikepdf.OutlineItem(
+                    "No Ref", pikepdf.Array([pikepdf.Name.Fit, pikepdf.Name.Fit])
+                )
+            )
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        rebuild_outlines([src], out, [Row(1, 1)])
+
+        with out.open_outline() as ol:
+            # Both should be dropped because they are invalid
+            assert len(ol.root) == 0
+
+    def test_named_dest_with_d_attribute(self):
+        """Test named destinations defined as dictionaries with a /D key."""
+        src = make_pdf(1)
+        # Define named dest as << /D [page /Fit] >> instead of just the array
+        dest_dict = pikepdf.Dictionary(
+            D=pikepdf.Array([src.pages[0].obj, pikepdf.Name.Fit])
+        )
+
+        if pikepdf.Name.Names not in src.Root:
+            src.Root.Names = src.make_indirect(pikepdf.Dictionary())
+        nt = pikepdf.NameTree.new(src)
+        nt["complex-dest"] = dest_dict
+        src.Root.Names.Dests = nt.obj
+
+        add_named_dest_bookmark(src, "Complex", "complex-dest")
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        rebuild_outlines([src], out, [Row(1, 1)])
+
+        with out.open_outline() as ol:
+            assert len(ol.root) == 1
+            assert named_dest_page_index(out, "f0-complex-dest") == 0
+
+    def test_destination_coordinate_scaling(self):
+        """Test scaling of XYZ and FitR coordinates based on row scale factor."""
+        src = make_pdf(1)
+        # XYZ: [page, /XYZ, left, top, zoom]
+        dest_xyz = pikepdf.Array([src.pages[0].obj, pikepdf.Name.XYZ, 100, 200, 0])
+        # FitR: [page, /FitR, left, bottom, right, top]
+        dest_fitr = pikepdf.Array([src.pages[0].obj, pikepdf.Name.FitR, 10, 20, 30, 40])
+
+        with src.open_outline() as ol:
+            ol.root.append(pikepdf.OutlineItem("XYZ", dest_xyz))
+            ol.root.append(pikepdf.OutlineItem("FitR", dest_fitr))
+        src = roundtrip(src)
+
+        out = make_pdf(1)
+        row = Row(1, 1)
+        row.scale = 2.0
+        pages = [row]
+
+        rebuild_outlines([src], out, pages)
+        # Note: We don't roundtrip 'out' yet if we want to check pikepdf object properties
+        # before they are serialized/dereferenced.
+
+        with out.open_outline() as ol:
+            # Use list() on the destination array to allow standard Python indexing/slicing
+            dest0 = list(ol.root[0].destination)
+            assert [float(dest0[2]), float(dest0[3])] == [200.0, 400.0]
+
+            dest1 = list(ol.root[1].destination)
+            assert [float(x) for x in dest1[2:6]] == [20.0, 40.0, 60.0, 80.0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Outline styles and open/closed state
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineStylesAndState:
+    """Tests for visual styles (colors/flags) and collapsed/expanded states."""
+
+    def test_styles_and_closed_state_preserved(self):
+        """Color, font flags, and default closed state should survive remapping."""
+        src = make_pdf(2)
+        with src.open_outline() as ol:
+            parent = pikepdf.OutlineItem("Styled Parent", 0)
+            # Give the new item a dictionary to hold custom styles ---
+            parent.obj = pikepdf.Dictionary()
+            # Set color to red [1.0, 0.0, 0.0] and font to bold-italic (3)
+            parent.obj[pikepdf.Name.C] = pikepdf.Array([1.0, 0.0, 0.0])
+            parent.obj[pikepdf.Name.F] = 3
+            # Add a child so the parent has something to collapse
+            child = pikepdf.OutlineItem("Child", 1)
+            parent.children.append(child)
+            parent.is_closed = True
+            ol.root.append(parent)
+        src = roundtrip(src)
+        out = make_pdf(2)
+        pages = [Row(1, 1), Row(1, 2)]
+        rebuild_outlines([src], out, pages)
+        out = roundtrip(out)
+        with out.open_outline() as ol:
+            assert len(ol.root) == 1
+            parent_out = ol.root[0]
+            # Verify the color and style flags carried over
+            assert pikepdf.Name.C in parent_out.obj
+            assert list(parent_out.obj[pikepdf.Name.C]) == [1.0, 0.0, 0.0]
+            assert pikepdf.Name.F in parent_out.obj
+            assert parent_out.obj[pikepdf.Name.F] == 3
+            # Verify it is still closed
+            assert parent_out.is_closed is True


### PR DESCRIPTION
Bookmarks from the source PDF(s) are now remapped to reflect the new page positions rather than being silently dropped. For this PR, this is applied only in the export_doc path (i.e. when start_with_empty is set), for single-file output.

The new `exporter_outlines.py` module handles:

- Bookmarks pointing to reordered, subsetted, or duplicated pages
- Named destinations (remapped with a fN- prefix to avoid collisions when merging multiple files)
- Multi-file merges (bookmarks from all source files are combined)
- Nested bookmarks (parents with no valid destination are retained if they have surviving children)
- GoTo actions as well as direct destinations

Fixes #339, #1348

EDIT:
This option is used when "Preserve document information from the first file opened" is unchecked in the preferences dialog.