### PR TITLE
fix #1395 by working around new pikepdf bug

### DIFF
--- a/pdfarranger/exporter_outlines.py
+++ b/pdfarranger/exporter_outlines.py
@@ -100,11 +100,7 @@ class OutlineRemapper:
     def _new_dest_array(
         self, dest_array, target_page_obj, file_idx, scale, original_name
     ):
-        new_dest_array = pikepdf.Array()
-        new_dest_array.append(target_page_obj)
         d_type = dest_array[1]
-        new_dest_array.append(d_type)
-        # Identify coordinate parameters based on destination type
         coord_indices = []
         if d_type == pikepdf.Name.XYZ:
             coord_indices = [2, 3]  # left, top (zoom ratio at index 4 is not scaled)
@@ -117,15 +113,18 @@ class OutlineRemapper:
             coord_indices = [2]  # [top] or [left]
         elif d_type == pikepdf.Name.FitR:
             coord_indices = [2, 3, 4, 5]  # [left, bottom, right, top]
-        # Apply scale directly to coordinates
+
+        items = [target_page_obj, d_type]
         for i in range(2, len(dest_array)):
             val = dest_array[i]
             if i in coord_indices and isinstance(val, (int, float, decimal.Decimal)):
-                new_dest_array.append(float(val) * scale)
+                items.append(float(val) * scale)
             elif isinstance(val, pikepdf.Object) and val.is_indirect:
-                new_dest_array.append(self.pdf_output.copy_foreign(val))
+                items.append(self.pdf_output.copy_foreign(val))
             else:
-                new_dest_array.append(val)
+                items.append(val)  # None (PDF null) is fine here
+
+        new_dest_array = pikepdf.Array(items)
         if original_name:
             new_name_str = f"f{file_idx}-{original_name}"
             self.new_named_dests.append((new_name_str, new_dest_array))

--- a/tests/test_exporter_outlines.py
+++ b/tests/test_exporter_outlines.py
@@ -850,3 +850,48 @@ class TestOutlineStylesAndState:
             assert parent_out.obj[pikepdf.Name.F] == 3
             # Verify it is still closed
             assert parent_out.is_closed is True
+
+
+# ---------------------------------------------------------------------------
+# Issue 1395
+# ---------------------------------------------------------------------------
+
+
+def test_null_coordinates_in_xyz_destination():
+    """
+    XYZ destinations with null coordinates (e.g. [page /XYZ null null null])
+    must survive remapping. This is the standard PDF idiom meaning 'inherit
+    current position/zoom'. Broke in pikepdf 10.6+ after the pybind11→nanobind
+    migration (Array.append(None) stopped accepting None).
+    """
+    src = make_pdf(2)
+    with src.open_outline() as ol:
+        for i, title in enumerate(["Chapter 1", "Chapter 2"]):
+            ol.root.append(
+                pikepdf.OutlineItem(
+                    title,
+                    pikepdf.Array(
+                        [src.pages[i].obj, pikepdf.Name.XYZ, None, None, None]
+                    ),
+                )
+            )
+    src = roundtrip(src)
+
+    out = make_pdf(2)
+    pages = [Row(1, 1), Row(1, 2)]
+    rebuild_outlines([src], out, pages)
+    out = roundtrip(out)
+
+    with out.open_outline() as ol:
+        assert len(ol.root) == 2
+        assert ol.root[0].title == "Chapter 1"
+        assert ol.root[1].title == "Chapter 2"
+        assert dest_page_index(out, ol.root[0].destination) == 0
+        assert dest_page_index(out, ol.root[1].destination) == 1
+        # Null coordinates must be preserved, not dropped or mangled
+        for item in ol.root:
+            dest = item.destination
+            assert dest[1] == pikepdf.Name.XYZ
+            assert dest[2] is None
+            assert dest[3] is None
+            assert dest[4] is None


### PR DESCRIPTION
pikepdf 10.6 to 10.7.1 break this pattern:
```
arr = pikepdf.Array()
arr.append(None)
```
This caused the crash in #1395. This patch gives a workaround, which is probably a small improvement to the code in any case: we construct a python list and convert it to a pikepdf Array at the end rather than appending items one by one to a pikepdf Array.

Fixes #1395