### PR TITLE
add manual trigger for install.yml

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,6 +2,7 @@ name: pdfarranger
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
Adds `workflow_dispatch` to the CI workflow triggers, enabling the workflow to be manually triggered.

This is useful for testing branches in forks which are synchronized with this repo, without having to first open a PR, e.g., with
```
gh workflow run install.yml --ref my-feature-branch
```